### PR TITLE
remove deref and derefWrite functions from spec

### DIFF
--- a/_spec/austral-pervasive.md
+++ b/_spec/austral-pervasive.md
@@ -39,32 +39,6 @@ The `Either` type is used to represent values which may have one of two distinct
 possibilities. For example, a function might return a value of type
 `Either[Error, Result]`.
 
-### `deref` Function {#austral.pervasive-deref}
-
-Declaration:
-
-```austral
-generic [T: Free, R: Region]
-function deref(ref: &[T, R]): T;
-```
-
-Description:
-
-The `deref` function loads the value pointed to by a read reference.
-
-### `derefWrite` Function {#austral.pervasive-derefwrite}
-
-Declaration:
-
-```austral
-generic [T: Free, R: Region]
-function derefWrite(ref: &![T, R]): T;
-```
-
-Description:
-
-The `derefWrite` function loads the value pointed to by a write reference.
-
 ### `fixedArraySize` Function {#austral.pervasive-fixedarraysize}
 
 Declaration:

--- a/spec/spec.html
+++ b/spec/spec.html
@@ -19,114 +19,187 @@
       <div class="toc-box">
         <nav id="TOC" role="doc-toc">
           <ul>
-          <li><a href="#intro">Introduction</a></li>
-          <li><a href="#goals">Design Goals</a></li>
-          <li><a href="#rationale">Rationale</a>
+          <li><a href="#intro" id="toc-intro">Introduction</a></li>
+          <li><a href="#goals" id="toc-goals">Design Goals</a></li>
+          <li><a href="#rationale" id="toc-rationale">Rationale</a>
           <ul>
-          <li><a href="#rationale-syntax">Syntax</a></li>
-          <li><a href="#rationale-linear-types">Linear Types</a></li>
-          <li><a href="#rationale-errors">Error Handling</a></li>
-          <li><a href="#rationale-cap">Capability-Based Security</a></li>
+          <li><a href="#rationale-syntax"
+          id="toc-rationale-syntax">Syntax</a></li>
+          <li><a href="#rationale-linear-types"
+          id="toc-rationale-linear-types">Linear Types</a></li>
+          <li><a href="#rationale-errors"
+          id="toc-rationale-errors">Error Handling</a></li>
+          <li><a href="#rationale-cap"
+          id="toc-rationale-cap">Capability-Based Security</a></li>
           </ul></li>
-          <li><a href="#syntax">Syntax</a>
+          <li><a href="#syntax" id="toc-syntax">Syntax</a>
           <ul>
-          <li><a href="#syntax-meta">Meta-Language</a></li>
-          <li><a href="#syntax-modules">Modules</a></li>
-          <li><a href="#syntax-declarations">Declarations</a></li>
-          <li><a href="#syntax-identifiers">Identifiers</a></li>
-          <li><a href="#syntax-comments">Comments and Documentation</a></li>
-          <li><a href="#syntax-literals">Literals</a></li>
-          <li><a href="#syntax-aux">Auxiliary Non-Terminals</a></li>
+          <li><a href="#syntax-meta"
+          id="toc-syntax-meta">Meta-Language</a></li>
+          <li><a href="#syntax-modules"
+          id="toc-syntax-modules">Modules</a></li>
+          <li><a href="#syntax-declarations"
+          id="toc-syntax-declarations">Declarations</a></li>
+          <li><a href="#syntax-identifiers"
+          id="toc-syntax-identifiers">Identifiers</a></li>
+          <li><a href="#syntax-comments"
+          id="toc-syntax-comments">Comments and Documentation</a></li>
+          <li><a href="#syntax-literals"
+          id="toc-syntax-literals">Literals</a></li>
+          <li><a href="#syntax-aux" id="toc-syntax-aux">Auxiliary
+          Non-Terminals</a></li>
           </ul></li>
-          <li><a href="#modules">Module System</a>
+          <li><a href="#modules" id="toc-modules">Module System</a>
           <ul>
-          <li><a href="#module-interfaces">Module Interfaces</a></li>
-          <li><a href="#module-bodies">Module Bodies</a></li>
-          <li><a href="#module-imports">Imports</a></li>
-          <li><a href="#import-nicknames">Import Nicknames</a></li>
-          <li><a href="#instance-imports">Instance Imports</a></li>
-          <li><a href="#unsafe-modules">Unsafe Modules</a></li>
-          <li><a href="#module-examples">Examples</a></li>
+          <li><a href="#module-interfaces"
+          id="toc-module-interfaces">Module Interfaces</a></li>
+          <li><a href="#module-bodies" id="toc-module-bodies">Module
+          Bodies</a></li>
+          <li><a href="#module-imports"
+          id="toc-module-imports">Imports</a></li>
+          <li><a href="#import-nicknames"
+          id="toc-import-nicknames">Import Nicknames</a></li>
+          <li><a href="#instance-imports"
+          id="toc-instance-imports">Instance Imports</a></li>
+          <li><a href="#unsafe-modules" id="toc-unsafe-modules">Unsafe
+          Modules</a></li>
+          <li><a href="#module-examples"
+          id="toc-module-examples">Examples</a></li>
           </ul></li>
-          <li><a href="#types">Type System</a>
+          <li><a href="#types" id="toc-types">Type System</a>
           <ul>
-          <li><a href="#type-universes">Type Universes</a></li>
-          <li><a href="#linear-types">Linear Types</a></li>
-          <li><a href="#type-parameters">Type Parameters</a></li>
-          <li><a href="#type-parameter-constraints">Type Parameter Constraints</a></li>
-          <li><a href="#declaring-types">Declaring Types</a></li>
-          <li><a href="#built-in-types">Built-In Types</a></li>
+          <li><a href="#type-universes" id="toc-type-universes">Type
+          Universes</a></li>
+          <li><a href="#linear-types" id="toc-linear-types">Linear
+          Types</a></li>
+          <li><a href="#type-parameters" id="toc-type-parameters">Type
+          Parameters</a></li>
+          <li><a href="#type-parameter-constraints"
+          id="toc-type-parameter-constraints">Type Parameter
+          Constraints</a></li>
+          <li><a href="#declaring-types"
+          id="toc-declaring-types">Declaring Types</a></li>
+          <li><a href="#built-in-types" id="toc-built-in-types">Built-In
+          Types</a></li>
           </ul></li>
-          <li><a href="#type-classes">Type Classes</a>
+          <li><a href="#type-classes" id="toc-type-classes">Type
+          Classes</a>
           <ul>
-          <li><a href="#type-class-uniqueness">Instance Uniqueness</a></li>
-          <li><a href="#instance-resolution">Instance Resolution</a></li>
+          <li><a href="#type-class-uniqueness"
+          id="toc-type-class-uniqueness">Instance Uniqueness</a></li>
+          <li><a href="#instance-resolution"
+          id="toc-instance-resolution">Instance Resolution</a></li>
           </ul></li>
-          <li><a href="#decl">Declarations</a>
+          <li><a href="#decl" id="toc-decl">Declarations</a>
           <ul>
-          <li><a href="#opaque-constant">Opaque Constant</a></li>
-          <li><a href="#constant-definition">Constant Definition</a></li>
-          <li><a href="#record-definition">Record Definition</a></li>
-          <li><a href="#union-definition">Union Definition</a></li>
-          <li><a href="#function-declaration">Function Declaration</a></li>
-          <li><a href="#function-definition">Function Definition</a></li>
-          <li><a href="#typeclass-definition">Typeclass Definition</a></li>
-          <li><a href="#instance-declaration">Instance Declaration</a></li>
-          <li><a href="#instance-definition">Instance Definition</a></li>
+          <li><a href="#opaque-constant" id="toc-opaque-constant">Opaque
+          Constant</a></li>
+          <li><a href="#constant-definition"
+          id="toc-constant-definition">Constant Definition</a></li>
+          <li><a href="#record-definition"
+          id="toc-record-definition">Record Definition</a></li>
+          <li><a href="#union-definition"
+          id="toc-union-definition">Union Definition</a></li>
+          <li><a href="#function-declaration"
+          id="toc-function-declaration">Function Declaration</a></li>
+          <li><a href="#function-definition"
+          id="toc-function-definition">Function Definition</a></li>
+          <li><a href="#typeclass-definition"
+          id="toc-typeclass-definition">Typeclass Definition</a></li>
+          <li><a href="#instance-declaration"
+          id="toc-instance-declaration">Instance Declaration</a></li>
+          <li><a href="#instance-definition"
+          id="toc-instance-definition">Instance Definition</a></li>
           </ul></li>
-          <li><a href="#stmt">Statements</a>
+          <li><a href="#stmt" id="toc-stmt">Statements</a>
           <ul>
-          <li><a href="#stmt-skip">Skip Statement</a></li>
-          <li><a href="#stmt-let">Let Statement</a></li>
-          <li><a href="#stmt-let-destructure">Let Destructure Statement</a></li>
-          <li><a href="#stmt-assign">Assignment Statement</a></li>
-          <li><a href="#stmt-if">If Statement</a></li>
-          <li><a href="#stmt-case">Case Statement</a></li>
-          <li><a href="#stmt-while">While Loop</a></li>
-          <li><a href="#stmt-for">For Loop</a></li>
-          <li><a href="#stmt-borrow">Borrow Statement</a></li>
-          <li><a href="#stmt-discard">Discarding Statement</a></li>
-          <li><a href="#stmt-return">Return Statement</a></li>
+          <li><a href="#stmt-skip" id="toc-stmt-skip">Skip
+          Statement</a></li>
+          <li><a href="#stmt-let" id="toc-stmt-let">Let
+          Statement</a></li>
+          <li><a href="#stmt-let-destructure"
+          id="toc-stmt-let-destructure">Let Destructure
+          Statement</a></li>
+          <li><a href="#stmt-assign" id="toc-stmt-assign">Assignment
+          Statement</a></li>
+          <li><a href="#stmt-if" id="toc-stmt-if">If Statement</a></li>
+          <li><a href="#stmt-case" id="toc-stmt-case">Case
+          Statement</a></li>
+          <li><a href="#stmt-while" id="toc-stmt-while">While
+          Loop</a></li>
+          <li><a href="#stmt-for" id="toc-stmt-for">For Loop</a></li>
+          <li><a href="#stmt-borrow" id="toc-stmt-borrow">Borrow
+          Statement</a></li>
+          <li><a href="#stmt-discard" id="toc-stmt-discard">Discarding
+          Statement</a></li>
+          <li><a href="#stmt-return" id="toc-stmt-return">Return
+          Statement</a></li>
           </ul></li>
-          <li><a href="#expr">Expressions</a>
+          <li><a href="#expr" id="toc-expr">Expressions</a>
           <ul>
-          <li><a href="#expr-nil">Nil Constant</a></li>
-          <li><a href="#expr-bool">Boolean Constant</a></li>
-          <li><a href="#expr-int">Integer Constant</a></li>
-          <li><a href="#expr-float">Float Constant</a></li>
-          <li><a href="#expr-str">String Constant</a></li>
-          <li><a href="#expr-var">Variable Expression</a></li>
-          <li><a href="#expr-arith">Arithmetic Expression</a></li>
-          <li><a href="#expr-funcall">Function Call</a></li>
-          <li><a href="#expr-methcall">Method Call</a></li>
-          <li><a href="#expr-rec-cons">Record Constructor</a></li>
-          <li><a href="#expr-union-cons">Union Constructor</a></li>
-          <li><a href="#expr-case">Cast Expression</a></li>
-          <li><a href="#expr-comp">Comparison Expression</a></li>
-          <li><a href="#expr-conj">Conjunction Expression</a></li>
-          <li><a href="#expr-disj">Disjunction Expression</a></li>
-          <li><a href="#negation-expression">Negation Expression</a></li>
-          <li><a href="#expr-if">If Expression</a></li>
-          <li><a href="#expr-path">Path Expression</a></li>
-          <li><a href="#expr-deref">Dereference Expression</a></li>
-          <li><a href="#expr-borrow">Borrow Expressions</a></li>
-          <li><a href="#expr-sizeof">sizeof Expression</a></li>
+          <li><a href="#expr-nil" id="toc-expr-nil">Nil
+          Constant</a></li>
+          <li><a href="#expr-bool" id="toc-expr-bool">Boolean
+          Constant</a></li>
+          <li><a href="#expr-int" id="toc-expr-int">Integer
+          Constant</a></li>
+          <li><a href="#expr-float" id="toc-expr-float">Float
+          Constant</a></li>
+          <li><a href="#expr-str" id="toc-expr-str">String
+          Constant</a></li>
+          <li><a href="#expr-var" id="toc-expr-var">Variable
+          Expression</a></li>
+          <li><a href="#expr-arith" id="toc-expr-arith">Arithmetic
+          Expression</a></li>
+          <li><a href="#expr-funcall" id="toc-expr-funcall">Function
+          Call</a></li>
+          <li><a href="#expr-methcall" id="toc-expr-methcall">Method
+          Call</a></li>
+          <li><a href="#expr-rec-cons" id="toc-expr-rec-cons">Record
+          Constructor</a></li>
+          <li><a href="#expr-union-cons" id="toc-expr-union-cons">Union
+          Constructor</a></li>
+          <li><a href="#expr-case" id="toc-expr-case">Cast
+          Expression</a></li>
+          <li><a href="#expr-comp" id="toc-expr-comp">Comparison
+          Expression</a></li>
+          <li><a href="#expr-conj" id="toc-expr-conj">Conjunction
+          Expression</a></li>
+          <li><a href="#expr-disj" id="toc-expr-disj">Disjunction
+          Expression</a></li>
+          <li><a href="#negation-expression"
+          id="toc-negation-expression">Negation Expression</a></li>
+          <li><a href="#expr-if" id="toc-expr-if">If Expression</a></li>
+          <li><a href="#expr-path" id="toc-expr-path">Path
+          Expression</a></li>
+          <li><a href="#expr-deref" id="toc-expr-deref">Dereference
+          Expression</a></li>
+          <li><a href="#expr-borrow" id="toc-expr-borrow">Borrow
+          Expressions</a></li>
+          <li><a href="#expr-sizeof" id="toc-expr-sizeof">sizeof
+          Expression</a></li>
           </ul></li>
-          <li><a href="#linearity">Linearity Checking</a></li>
-          <li><a href="#builtin">Built-In Modules</a>
+          <li><a href="#linearity" id="toc-linearity">Linearity
+          Checking</a></li>
+          <li><a href="#builtin" id="toc-builtin">Built-In Modules</a>
           <ul>
-          <li><a href="#austral.memory">Austral.Memory Module</a></li>
-          <li><a href="#austral.pervasive">Austral.Pervasive Module</a></li>
+          <li><a href="#austral.memory"
+          id="toc-austral.memory">Austral.Memory Module</a></li>
+          <li><a href="#austral.pervasive"
+          id="toc-austral.pervasive">Austral.Pervasive Module</a></li>
           </ul></li>
-          <li><a href="#ffi">Foreign Interfaces</a>
+          <li><a href="#ffi" id="toc-ffi">Foreign Interfaces</a>
           <ul>
-          <li><a href="#c-ffi">The C Interface</a></li>
+          <li><a href="#c-ffi" id="toc-c-ffi">The C Interface</a></li>
           </ul></li>
-          <li><a href="#style-guide">Style Guide</a>
+          <li><a href="#style-guide" id="toc-style-guide">Style
+          Guide</a>
           <ul>
-          <li><a href="#style-case-convention">Case Convention</a></li>
+          <li><a href="#style-case-convention"
+          id="toc-style-case-convention">Case Convention</a></li>
           </ul></li>
-          <li><a href="#license">Appendix A: GNU Free Documentation License</a></li>
+          <li><a href="#license" id="toc-license">Appendix A: GNU Free
+          Documentation License</a></li>
           </ul>
         </nav>
       </div>
@@ -137,64 +210,162 @@
 <p>Time, which attenuates all memories, sharpens that of the Zahir.</p>
 <p>— Jorge Luis Borges, <em>El Zahir</em></p>
 </blockquote>
-<p>Austral is a new programming language. It is designed to enable writing code that is secure, readable, maintainble, robust, and long-lasting.</p>
+<p>Austral is a new programming language. It is designed to enable
+writing code that is secure, readable, maintainble, robust, and
+long-lasting.</p>
 <h1 id="goals">Design Goals</h1>
 <p>This section lists the design goals for Austral.</p>
 <ol type="1">
-<li><p><strong>Simplicity.</strong> This is the <em>sine qua non</em>: the language must be simple enough to fit in a single person’s head. We call this “fits-in-head simplicity”. Notably, many languages fail to clear this bar. C++ is the prototypical example, already <a href="https://www.stroustrup.com/P0977-remember-the-vasa.pdf">its author has warned</a> against excess complexity (in vain).</p>
+<li><p><strong>Simplicity.</strong> This is the <em>sine qua non</em>:
+the language must be simple enough to fit in a single person’s head. We
+call this “fits-in-head simplicity”. Notably, many languages fail to
+clear this bar. C++ is the prototypical example, already <a
+href="https://www.stroustrup.com/P0977-remember-the-vasa.pdf">its author
+has warned</a> against excess complexity (in vain).</p>
 <p>Simplicity is valuable for multiple reasons:</p>
 <ol type="1">
-<li><p>It makes the language easier to implement, which makes it feasible to have multiple implementations, reducing vendor lock-in risk.</p></li>
-<li><p>It makes the language easier to learn, which is good for beginners.</p></li>
-<li><p>It makes code easier to reason about, because there are fewer overlapping language features to consider.</p></li>
+<li><p>It makes the language easier to implement, which makes it
+feasible to have multiple implementations, reducing vendor lock-in
+risk.</p></li>
+<li><p>It makes the language easier to learn, which is good for
+beginners.</p></li>
+<li><p>It makes code easier to reason about, because there are fewer
+overlapping language features to consider.</p></li>
 </ol>
-<p>Simplicity is defined in terms of <a href="https://en.wikipedia.org/wiki/Kolmogorov_complexity">Kolmogorov complexity</a>: a system is simple not when it forgives mistakes or is beginner-friendly or is easy to use. A system is simple when <em>it can be described briefly</em>.</p>
+<p>Simplicity is defined in terms of <a
+href="https://en.wikipedia.org/wiki/Kolmogorov_complexity">Kolmogorov
+complexity</a>: a system is simple not when it forgives mistakes or is
+beginner-friendly or is easy to use. A system is simple when <em>it can
+be described briefly</em>.</p>
 <p>Two crucial measures of simplicity are:</p>
 <ol type="1">
-<li><p>Language lawyering should be impossible. If people can argue about what some code prints out, that’s a language failure. If code can be ambiguous or obsfuscated, that is not a failure of the programmer but a failure of the language.</p></li>
-<li><p>A programmer should be able to learn the language in its entirety by reading this specification.</p></li>
+<li><p>Language lawyering should be impossible. If people can argue
+about what some code prints out, that’s a language failure. If code can
+be ambiguous or obsfuscated, that is not a failure of the programmer but
+a failure of the language.</p></li>
+<li><p>A programmer should be able to learn the language in its entirety
+by reading this specification.</p></li>
 </ol>
-<p>Simplicity also means that Austral is a generally low-level language. There is no garbage collector, not primarily because of performance concerns, but because it would require an arbitrarily complex runtime.</p></li>
-<li><p><strong>Correctness.</strong> This is an intangible, but generally, the measure of how much a language enables programmers to write correct code is: if the code compiles, it should work. With the caveat that said code should use the relevant safety features, since it is possible to write unsafe C in any language.</p>
-<p>There is a steep tradeoff curve between correctness and simplicity: simple type system features provide 80% of correctness. The remaining 20% consists of things like:</p>
+<p>Simplicity also means that Austral is a generally low-level language.
+There is no garbage collector, not primarily because of performance
+concerns, but because it would require an arbitrarily complex
+runtime.</p></li>
+<li><p><strong>Correctness.</strong> This is an intangible, but
+generally, the measure of how much a language enables programmers to
+write correct code is: if the code compiles, it should work. With the
+caveat that said code should use the relevant safety features, since it
+is possible to write unsafe C in any language.</p>
+<p>There is a steep tradeoff curve between correctness and simplicity:
+simple type system features provide 80% of correctness. The remaining
+20% consists of things like:</p>
 <ol type="1">
 <li>Statically proving that there are no integer overflows.</li>
 <li>Proving that all array indexing calls are within array bounds.</li>
 <li>More generally: proving that function contracts are upheld.</li>
 </ol>
-<p>Doing this with full generality requires either interactive theorem proving or SMT solving, which is a massive increase in implementational complexity (Z3 is 300,000 lines of C++). Given that this is an active area of research in computer science, we sacrifice absolute safety for implementational simplicity.</p></li>
-<li><p><strong>Security.</strong> It should not be difficult to write secure code. That is: ordinary language features should not be strewn with footguns that make security impossible.</p></li>
-<li><p><strong>Readability.</strong> We are not typists, we are programmers. And because code is read far more than it is written, we should optimize for readability, perhaps at the cost of writability.</p></li>
-<li><p><strong>Maintainability.</strong> Leslie Lamport <a href="https://lamport.azurewebsites.net/pubs/future-of-computing.pdf">wrote</a>:</p>
+<p>Doing this with full generality requires either interactive theorem
+proving or SMT solving, which is a massive increase in implementational
+complexity (Z3 is 300,000 lines of C++). Given that this is an active
+area of research in computer science, we sacrifice absolute safety for
+implementational simplicity.</p></li>
+<li><p><strong>Security.</strong> It should not be difficult to write
+secure code. That is: ordinary language features should not be strewn
+with footguns that make security impossible.</p></li>
+<li><p><strong>Readability.</strong> We are not typists, we are
+programmers. And because code is read far more than it is written, we
+should optimize for readability, perhaps at the cost of
+writability.</p></li>
+<li><p><strong>Maintainability.</strong> Leslie Lamport <a
+href="https://lamport.azurewebsites.net/pubs/future-of-computing.pdf">wrote</a>:</p>
 <blockquote>
-<p>An automobile runs, a program does not. (Computers run, but I’m not discussing them.) An automobile requires mainte- nance, a program does not. A program does not need to have its stack cleaned every 10,000 miles. Its if statements do not wear out through use. (Previously undetected errors may need to be corrected, or it might be necessary to write a new but sim- ilar program, but those are different matters.) An automobile is a piece of machinery, a program is some kind of mathematical expression.</p>
+<p>An automobile runs, a program does not. (Computers run, but I’m not
+discussing them.) An automobile requires mainte- nance, a program does
+not. A program does not need to have its stack cleaned every 10,000
+miles. Its if statements do not wear out through use. (Previously
+undetected errors may need to be corrected, or it might be necessary to
+write a new but sim- ilar program, but those are different matters.) An
+automobile is a piece of machinery, a program is some kind of
+mathematical expression.</p>
 </blockquote>
-<p>Working programmers know this is far from reality. Bitrot, not permanence, is the norm. However, bitrot is avoidable by doing careful design up-front, prioritizing stability in the design, and, crucially: saying <em>no</em> to proposed language features. The goal is that code written in Austral that depends only on the standard library should compile and run without changes decades into the future.</p></li>
-<li><p><strong>Modularity.</strong> Software is built out of hierarchically organized modules, accessible through interfaces. Languages have more-or-less explicit support for this:</p>
+<p>Working programmers know this is far from reality. Bitrot, not
+permanence, is the norm. However, bitrot is avoidable by doing careful
+design up-front, prioritizing stability in the design, and, crucially:
+saying <em>no</em> to proposed language features. The goal is that code
+written in Austral that depends only on the standard library should
+compile and run without changes decades into the future.</p></li>
+<li><p><strong>Modularity.</strong> Software is built out of
+hierarchically organized modules, accessible through interfaces.
+Languages have more-or-less explicit support for this:</p>
 <ol type="1">
-<li><p>In C, all declarations exist in the same namespace, and textual inclusion and the separation of header and implementation files provides a loose modularity, enforced only through style guides and programmer discipline.</p></li>
-<li><p>In Python, modules exist, their names and paths are tied to the filesystem, and the accessibility of identifiers is determined by their names.</p></li>
-<li><p>In Rust and Java, visibility modifiers are attached to declarations to make them public or private.</p></li>
+<li><p>In C, all declarations exist in the same namespace, and textual
+inclusion and the separation of header and implementation files provides
+a loose modularity, enforced only through style guides and programmer
+discipline.</p></li>
+<li><p>In Python, modules exist, their names and paths are tied to the
+filesystem, and the accessibility of identifiers is determined by their
+names.</p></li>
+<li><p>In Rust and Java, visibility modifiers are attached to
+declarations to make them public or private.</p></li>
 </ol>
-<p>Austral’s module system is inspired by those of Ada, Modula-2, and Standard ML, with the restriction that there are no generic modules (as in Ada or Modula-3) or functors (as in Standard ML or OCaml), that is: all modules are first-order.</p>
-<p>Modules are given explicit names are are not tied to any particular file system structure. Modules are split in two textual parts (effectively two files), a module interface and a module body, with strict separation between the two. The declarations in the module interface file are accessible from without, and the declarations in the module body file are private.</p>
-<p>Crucially, a module <code>A</code> that depends on a module <code>B</code> can be typechecked when the compiler only has access to the interface file of module <code>B</code>. That is: modules can be typechecked against each other before being implemented. This allows system interfaces to be designed up-front, and implemented in parallel.</p></li>
-<li><p><strong>Strictness.</strong> Gerald Jay Sussman and Hal Abelson <a href="https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book-Z-H-5.html">wrote</a>:</p>
+<p>Austral’s module system is inspired by those of Ada, Modula-2, and
+Standard ML, with the restriction that there are no generic modules (as
+in Ada or Modula-3) or functors (as in Standard ML or OCaml), that is:
+all modules are first-order.</p>
+<p>Modules are given explicit names are are not tied to any particular
+file system structure. Modules are split in two textual parts
+(effectively two files), a module interface and a module body, with
+strict separation between the two. The declarations in the module
+interface file are accessible from without, and the declarations in the
+module body file are private.</p>
+<p>Crucially, a module <code>A</code> that depends on a module
+<code>B</code> can be typechecked when the compiler only has access to
+the interface file of module <code>B</code>. That is: modules can be
+typechecked against each other before being implemented. This allows
+system interfaces to be designed up-front, and implemented in
+parallel.</p></li>
+<li><p><strong>Strictness.</strong> Gerald Jay Sussman and Hal Abelson
+<a
+href="https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book-Z-H-5.html">wrote</a>:</p>
 <blockquote>
-<p>Pascal is for building pyramids — imposing, breathtaking, static structures built by armies pushing heavy blocks into place. Lisp is for building organisms — imposing, breathtaking, dynamic structures built by squads fitting fluctuating myriads of simpler organisms into place.</p>
+<p>Pascal is for building pyramids — imposing, breathtaking, static
+structures built by armies pushing heavy blocks into place. Lisp is for
+building organisms — imposing, breathtaking, dynamic structures built by
+squads fitting fluctuating myriads of simpler organisms into place.</p>
 </blockquote>
-<p>Austral is decidedly a language for building pyramids. Code written in Austral is strict, rigid, crystalline, and <em>brittle</em>: minor changes are prone to breaking the build. We posit that this is a good thing.</p></li>
-<li><p><strong>Restraint.</strong> There is a widespread view in software engineering that errors are the responsibility of programmers, that “only a bad craftsperson complains about their tools”, and that the solution to catastrophic security vulnerabilities caused by the same underlying mechanisms is to simply write fewer bugs.</p>
-<p>We take the view that human error is an inescapable, intrinsic aspect of human activity. Human processes such as code review are only as good as the discipline of the people running them, who are often tired, burnt out, distracted, or otherwise unable to accurately simulate virtual machines (a task human brains were not evolved for), or facing business pressure to put expedience over correctness. Mechanical processes — such as type systems, type checking, formal verification, design by contract, static assertion checking, dynamic assertion checking — are independent of the skill of the programmer.</p>
-<p>Therefore: programmers need all possible mechanical aid to writing good code, up to the point where the implemention/semantic complexity exceeds the gains in correctness.</p>
-<p>Given the vast empirical evidence that humans are unable to predict the failure modes and security vulnerabilities in the code they write, Austral is designed to restrain programmer power and minimize footguns.</p></li>
+<p>Austral is decidedly a language for building pyramids. Code written
+in Austral is strict, rigid, crystalline, and <em>brittle</em>: minor
+changes are prone to breaking the build. We posit that this is a good
+thing.</p></li>
+<li><p><strong>Restraint.</strong> There is a widespread view in
+software engineering that errors are the responsibility of programmers,
+that “only a bad craftsperson complains about their tools”, and that the
+solution to catastrophic security vulnerabilities caused by the same
+underlying mechanisms is to simply write fewer bugs.</p>
+<p>We take the view that human error is an inescapable, intrinsic aspect
+of human activity. Human processes such as code review are only as good
+as the discipline of the people running them, who are often tired, burnt
+out, distracted, or otherwise unable to accurately simulate virtual
+machines (a task human brains were not evolved for), or facing business
+pressure to put expedience over correctness. Mechanical processes — such
+as type systems, type checking, formal verification, design by contract,
+static assertion checking, dynamic assertion checking — are independent
+of the skill of the programmer.</p>
+<p>Therefore: programmers need all possible mechanical aid to writing
+good code, up to the point where the implemention/semantic complexity
+exceeds the gains in correctness.</p>
+<p>Given the vast empirical evidence that humans are unable to predict
+the failure modes and security vulnerabilities in the code they write,
+Austral is designed to restrain programmer power and minimize
+footguns.</p></li>
 </ol>
 <h1 id="rationale">Rationale</h1>
 <p>This section explains and justifies the design of Austral.</p>
 <h2 id="rationale-syntax">Syntax</h2>
 <p>According to Wadler’s Law,</p>
 <blockquote>
-<p>In any language design, the total time spent discussing a feature in this list is proportional to two raised to the power of its position.</p>
+<p>In any language design, the total time spent discussing a feature in
+this list is proportional to two raised to the power of its
+position.</p>
 <ol start="0" type="1">
 <li>Semantics</li>
 <li>Syntax</li>
@@ -202,49 +373,93 @@
 <li>Lexical syntax of comments</li>
 </ol>
 </blockquote>
-<p>Therefore, I will begin by justifying the design of Austral’s syntax.</p>
+<p>Therefore, I will begin by justifying the design of Austral’s
+syntax.</p>
 <p>Austral’s syntax is characterized by:</p>
 <ol type="1">
-<li><p>Being statement-oriented rather than expression oriented.</p></li>
-<li><p>Preference over English-language keywords over non-alphanumeric symbols, e.g. <code>begin</code> and <code>end</code> rather than <code>{</code> and <code>}</code>, <code>bind</code> over <code>&gt;&gt;=</code>, etc.</p></li>
-<li><p>Delimiters include the name of the construct they terminate, e.g. <code>end if</code> and <code>end for</code>.</p></li>
-<li><p>Verbose names are preferred over inscrutable abbreviations.</p></li>
+<li><p>Being statement-oriented rather than expression
+oriented.</p></li>
+<li><p>Preference over English-language keywords over non-alphanumeric
+symbols, e.g. <code>begin</code> and <code>end</code> rather than
+<code>{</code> and <code>}</code>, <code>bind</code> over
+<code>&gt;&gt;=</code>, etc.</p></li>
+<li><p>Delimiters include the name of the construct they terminate,
+e.g. <code>end if</code> and <code>end for</code>.</p></li>
+<li><p>Verbose names are preferred over inscrutable
+abbreviations.</p></li>
 <li><p>Statements are terminated by semicolons.</p></li>
 </ol>
 <p>These decisions will be justified individually.</p>
 <h3 id="stmt-orientation">Statement Orientation</h3>
 <p>Syntax can be classified into three categories.</p>
 <ol type="1">
-<li><p><strong>Statement-Oriented:</strong> Like C, Pascal, and Ada. Statements and expressions form two distinct syntactic categories.</p></li>
-<li><p><strong>Pure Expression-Oriented Syntax:</strong> Like Lisp, Standard ML, OCaml, and Haskell. There are only expressions, and the syntax reflects this directly.</p></li>
-<li><p><strong>Mixed Syntax:</strong> Many newer languages, like Scala and Rust, fall into this category. At the AST level there is only one kind of thing: expressions. But the actual written syntax is made to resemble statement-oriented languages to make programmers more comfortable.</p></li>
+<li><p><strong>Statement-Oriented:</strong> Like C, Pascal, and Ada.
+Statements and expressions form two distinct syntactic
+categories.</p></li>
+<li><p><strong>Pure Expression-Oriented Syntax:</strong> Like Lisp,
+Standard ML, OCaml, and Haskell. There are only expressions, and the
+syntax reflects this directly.</p></li>
+<li><p><strong>Mixed Syntax:</strong> Many newer languages, like Scala
+and Rust, fall into this category. At the AST level there is only one
+kind of thing: expressions. But the actual written syntax is made to
+resemble statement-oriented languages to make programmers more
+comfortable.</p></li>
 </ol>
 <p>In <em>Epigrams in Programming</em>, Alan Perlis wrote:</p>
 <blockquote>
 <ol start="6" type="1">
-<li>Symmetry is a complexity-reducing concept (co-routines include subroutines); seek it everywhere.</li>
+<li>Symmetry is a complexity-reducing concept (co-routines include
+subroutines); seek it everywhere.</li>
 </ol>
 </blockquote>
-<p>Indeed, expression-oriented syntax is simpler (there is no duplication between e.g. <code>if</code> statements and <code>if</code> expressions) and symmetrical (there is only one syntactic category of code). But it suffers from excess generality in that it is possible to write things like:</p>
+<p>Indeed, expression-oriented syntax is simpler (there is no
+duplication between e.g. <code>if</code> statements and <code>if</code>
+expressions) and symmetrical (there is only one syntactic category of
+code). But it suffers from excess generality in that it is possible to
+write things like:</p>
 <pre><code>let x = (* A gigantic, inscrutable expression
            with multiple levels of `let` blocks. *)
 in
     ...</code></pre>
 <p>In short, nothing forces the programmer to factor things out.</p>
-<p>Furthermore, in pure expression-oriented languages of the ML family code has the ugly appearance of “hanging in the air”, there is little in terms of delimiters.</p>
+<p>Furthermore, in pure expression-oriented languages of the ML family
+code has the ugly appearance of “hanging in the air”, there is little in
+terms of delimiters.</p>
 <p>Three kinds of syntax.</p>
-<p>Mixed syntaxes are unprincipled because the textual syntax doesn’t match the AST, which makes it possible to abuse the syntax and write “interesting” code. For example, in Rust, the following:</p>
+<p>Mixed syntaxes are unprincipled because the textual syntax doesn’t
+match the AST, which makes it possible to abuse the syntax and write
+“interesting” code. For example, in Rust, the following:</p>
 <pre><code>let x = { let y; }</code></pre>
-<p>is a valid expression. <code>x</code> has the Unit type because the block expression ends in a semicolon, so it is evaluated to the Unit type.</p>
-<p>A statement-oriented syntax is less simple, but it forces code to be structurally simple, especially when combined with the restriction that uninitialized variables are not allowed. Then, the programmer is forced to factor out complicated control flow into chains of functions.</p>
-<p>Historically, there is one language that moved from an expression-oriented to a statement-oriented syntax: ALGOL W was expression-oriented; Pascal, its successor, was statement-oriented.</p>
+<p>is a valid expression. <code>x</code> has the Unit type because the
+block expression ends in a semicolon, so it is evaluated to the Unit
+type.</p>
+<p>A statement-oriented syntax is less simple, but it forces code to be
+structurally simple, especially when combined with the restriction that
+uninitialized variables are not allowed. Then, the programmer is forced
+to factor out complicated control flow into chains of functions.</p>
+<p>Historically, there is one language that moved from an
+expression-oriented to a statement-oriented syntax: ALGOL W was
+expression-oriented; Pascal, its successor, was statement-oriented.</p>
 <h3 id="rationale-keywords">Keywords over Symbols</h3>
-<p>Austral syntax prefers English-language words in place of symbols. This is because words are easier to search for, both locally and on a search engine, than a string of symbols.</p>
-<p>Additionally, words are read into sounds, which aids in remembering them, while a string like <code>&gt;&gt;=</code> can only be understood as a visual symbol.</p>
-<p>Using English-language keywords, however, does not mean we use a natural language inspired syntax, like Inform7. The problem with programming languages that use an English-like natural language syntax is that the syntax is a facade: programming languages are formal languages, sentences in a programming language have a rigid and ideally unambiguous interpretation.</p>
-<p>Programming languages should not hide their formal nature under a “friendly” facade of natural language syntax.</p>
+<p>Austral syntax prefers English-language words in place of symbols.
+This is because words are easier to search for, both locally and on a
+search engine, than a string of symbols.</p>
+<p>Additionally, words are read into sounds, which aids in remembering
+them, while a string like <code>&gt;&gt;=</code> can only be understood
+as a visual symbol.</p>
+<p>Using English-language keywords, however, does not mean we use a
+natural language inspired syntax, like Inform7. The problem with
+programming languages that use an English-like natural language syntax
+is that the syntax is a facade: programming languages are formal
+languages, sentences in a programming language have a rigid and ideally
+unambiguous interpretation.</p>
+<p>Programming languages should not hide their formal nature under a
+“friendly” facade of natural language syntax.</p>
 <h3 id="terminating-keywords">Terminating Keywords</h3>
-<p>In Austral, delimiters include the name of the construct they terminate. This is after Ada (and the Wirth tradition) and is in contrast to the C tradition. The reason for this is that it makes it easier to find one’s place in the code.</p>
+<p>In Austral, delimiters include the name of the construct they
+terminate. This is after Ada (and the Wirth tradition) and is in
+contrast to the C tradition. The reason for this is that it makes it
+easier to find one’s place in the code.</p>
 <p>Consider the following code:</p>
 <pre><code>void f() {
     for (int i = 0; i &lt; N; i++) {
@@ -257,7 +472,8 @@ in
         }
     }
 }</code></pre>
-<p>Suppose we want to add some code after the second for loop. In this case, it’s simple enough:</p>
+<p>Suppose we want to add some code after the second for loop. In this
+case, it’s simple enough:</p>
 <pre><code>void f() {
     for (int i = 0; i &lt; N; i++) {
         if (test()) {
@@ -270,7 +486,8 @@ in
         }
     }
 }</code></pre>
-<p>But suppose that instead of a call to <code>g()</code> we have multiple pages of code:</p>
+<p>But suppose that instead of a call to <code>g()</code> we have
+multiple pages of code:</p>
 <pre><code>void f() {
     for (int i = 0; i &lt; N; i++) {
         if (test()) {
@@ -282,13 +499,18 @@ in
         }
     }
 }</code></pre>
-<p>Then, when we scroll to the bottom of the function to add the code, we find this train of closing delimiters:</p>
+<p>Then, when we scroll to the bottom of the function to add the code,
+we find this train of closing delimiters:</p>
 <pre><code>                }
             }
         }
     }
 }</code></pre>
-<p>Which one of these corresponds to the second <code>for</code> loop? Unless we have an editor with folding support, we have to find the column where the second <code>for</code> loop begins, scroll down to the closing curly brace at that column position, and insert the code there. This is manual and error-prone.</p>
+<p>Which one of these corresponds to the second <code>for</code> loop?
+Unless we have an editor with folding support, we have to find the
+column where the second <code>for</code> loop begins, scroll down to the
+closing curly brace at that column position, and insert the code there.
+This is manual and error-prone.</p>
 <p>Consider the equivalent in an Ada-like syntax:</p>
 <pre><code>function f() is
     for (int i = 0; i &lt; N; i++) do
@@ -301,7 +523,8 @@ in
         end if;
     end for;
 end f;</code></pre>
-<p>Then, even if the code spans multiple pages, finding the second <code>for</code> loop is easy:</p>
+<p>Then, even if the code spans multiple pages, finding the second
+<code>for</code> loop is easy:</p>
 <pre><code>                end if;
             end for;
         end if;
@@ -315,34 +538,59 @@ end f;</code></pre>
 <li>The end of the first <code>for</code> loop.</li>
 <li>The end of the function <code>f</code>.</li>
 </ol>
-<p>Thus, delimiters which include the name of the construct they terminate involve more typing, but make code more readable.</p>
-<p>Note that this is often done in C and HTML code, where one finds things like this:</p>
+<p>Thus, delimiters which include the name of the construct they
+terminate involve more typing, but make code more readable.</p>
+<p>Note that this is often done in C and HTML code, where one finds
+things like this:</p>
 <pre><code>} // access check</code></pre>
 <p>or,</p>
 <pre><code>&lt;/table&gt; // user data table</code></pre>
-<p>However, declarations end with a simple <code>end</code>, not including the name of the declaration construct. This is because declarations are rarely nested, and including the name of the declaration would be unnecessarily verbose.</p>
+<p>However, declarations end with a simple <code>end</code>, not
+including the name of the declaration construct. This is because
+declarations are rarely nested, and including the name of the
+declaration would be unnecessarily verbose.</p>
 <h3 id="terseness">Terseness versus Verbosity</h3>
-<p>The rule is: verbose enough to be readable without context, terse enough that people will not be discouraged from factoring code into many small functions and types.</p>
+<p>The rule is: verbose enough to be readable without context, terse
+enough that people will not be discouraged from factoring code into many
+small functions and types.</p>
 <h3 id="semicolons">Semicolons</h3>
-<p>It is a common misconception that semicolons are needed for the compiler to know where a statement or expression ends. That is: that without semicolons, languages would be ambiguous. This obviously depends on the language grammar, but in the case of Austral it is not true, and the grammar would remain unambiguous even without semicolons.</p>
-<p>The purpose of the semicolon is to provide <em>redundancy</em>, which aids both reading and parser error recovery. For example, in the following code:</p>
+<p>It is a common misconception that semicolons are needed for the
+compiler to know where a statement or expression ends. That is: that
+without semicolons, languages would be ambiguous. This obviously depends
+on the language grammar, but in the case of Austral it is not true, and
+the grammar would remain unambiguous even without semicolons.</p>
+<p>The purpose of the semicolon is to provide <em>redundancy</em>, which
+aids both reading and parser error recovery. For example, in the
+following code:</p>
 <pre><code>let x : T := f(a, b, c;</code></pre>
-<p>The programmer has forgotten the closing parenthesis in a function call. However, the parser can report the error as soon as it encounters the semicolon.</p>
-<p>For many people, semicolons represent the distinction between an old and crusty language and a modern one, in which case the semicolon serves a function similar to the use of Comic Sans by the OpenBSD project.</p>
+<p>The programmer has forgotten the closing parenthesis in a function
+call. However, the parser can report the error as soon as it encounters
+the semicolon.</p>
+<p>For many people, semicolons represent the distinction between an old
+and crusty language and a modern one, in which case the semicolon serves
+a function similar to the use of Comic Sans by the OpenBSD project.</p>
 <h3 id="syntax-rationale-type-decl">Syntax of Type Declarations</h3>
-<p>The syntax of type declarations it designed to make explicit the analogy between functions and generic types: that is, generic types are essentially functions from types to a new type.</p>
+<p>The syntax of type declarations it designed to make explicit the
+analogy between functions and generic types: that is, generic types are
+essentially functions from types to a new type.</p>
 <p>Where function declarations look like this:</p>
 <p><span class="math display">\[
-\text{function} ~ \text{f} ( \text{p}_1: \tau_1, \dots, \text{p}_1: \tau_1 ): \tau_r ;
+\text{function} ~ \text{f} ( \text{p}_1: \tau_1, \dots, \text{p}_1:
+\tau_1 ): \tau_r ;
 \]</span></p>
 <p>A type declaration looks like:</p>
 <p><span class="math display">\[
 \text{type} ~ \tau [ \text{p}_1: k, \dots, \text{p}_1: k ]: u ;
 \]</span></p>
-<p>Here, type parameters are analogous to value parameters, kinds are analogous to types, and the universe is analogous to the return type.</p>
+<p>Here, type parameters are analogous to value parameters, kinds are
+analogous to types, and the universe is analogous to the return
+type.</p>
 <h2 id="rationale-linear-types">Linear Types</h2>
-<p>Resource-aware type systems can remove large categories of errors that have caused endless security vulnerabilities in a simple way. This section describes the options.</p>
-<p>This section begins with the motivation for linear types, then explains what linear types are and how they provide safety.</p>
+<p>Resource-aware type systems can remove large categories of errors
+that have caused endless security vulnerabilities in a simple way. This
+section describes the options.</p>
+<p>This section begins with the motivation for linear types, then
+explains what linear types are and how they provide safety.</p>
 <h3 id="rationale-linear-resources">Resources and Lifecycles</h3>
 <p>Consider a file handling API:</p>
 <pre><code>type File
@@ -352,35 +600,59 @@ File openFile(String path)
 File writeString(File file, String content)
 
 void closeFile(File file)</code></pre>
-<p>An experienced programmer understands the <em>implicit lifecycle</em> of the <code>File</code> object:</p>
+<p>An experienced programmer understands the <em>implicit lifecycle</em>
+of the <code>File</code> object:</p>
 <ol type="1">
-<li>We create a <code>File</code> handle by calling <code>openFile</code>.</li>
+<li>We create a <code>File</code> handle by calling
+<code>openFile</code>.</li>
 <li>We write to the handle zero or more times.</li>
 <li>We close the file handle by calling <code>closeFile</code>.</li>
 </ol>
 <p>We can depict this graphically like this:</p>
 <figure>
-<img src="/assets/spec/file-api.png" alt="" /><figcaption>A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’.</figcaption>
+<img src="/assets/spec/file-api.png"
+alt="A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’." />
+<figcaption aria-hidden="true">A graph with three nodes labeled
+‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from
+‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from
+‘writeString’ to itself, and from ‘writeString’ to
+‘closeFile’.</figcaption>
 </figure>
-<p>But, crucially: this lifecycle is <em>not enforced by the compiler</em>. There are a number of erroneous transitions that we don’t consider, but which are technically possible:</p>
+<p>But, crucially: this lifecycle is <em>not enforced by the
+compiler</em>. There are a number of erroneous transitions that we don’t
+consider, but which are technically possible:</p>
 <figure>
-<img src="/assets/spec/file-api-errors.png" alt="" /><figcaption>The graph from the previous figure, with a new node labeled ‘leak’, and with four new arrows in red: one from ‘closeFile’ to itself labeled ‘double close’, one from ‘closeFile’ to ‘writeString’ labeled ‘use after close’, one from ‘openFile’ to ‘leak’ labeled ‘forgot to close’, and one from ‘writeString’ to ‘leak’ also labeled ‘forgot to close’.</figcaption>
+<img src="/assets/spec/file-api-errors.png"
+alt="The graph from the previous figure, with a new node labeled ‘leak’, and with four new arrows in red: one from ‘closeFile’ to itself labeled ‘double close’, one from ‘closeFile’ to ‘writeString’ labeled ‘use after close’, one from ‘openFile’ to ‘leak’ labeled ‘forgot to close’, and one from ‘writeString’ to ‘leak’ also labeled ‘forgot to close’." />
+<figcaption aria-hidden="true">The graph from the previous figure, with
+a new node labeled ‘leak’, and with four new arrows in red: one from
+‘closeFile’ to itself labeled ‘double close’, one from ‘closeFile’ to
+‘writeString’ labeled ‘use after close’, one from ‘openFile’ to ‘leak’
+labeled ‘forgot to close’, and one from ‘writeString’ to ‘leak’ also
+labeled ‘forgot to close’.</figcaption>
 </figure>
 <p>These fall into two categories:</p>
 <ol type="1">
-<li><p><strong>Leaks:</strong> we can forget to call <code>closeFile</code>, e.g.:</p>
+<li><p><strong>Leaks:</strong> we can forget to call
+<code>closeFile</code>, e.g.:</p>
 <pre><code>let file = openFile(&quot;hello.txt&quot;)
 writeString(file, &quot;Hello, world!&quot;)
 // Forgot to close</code></pre></li>
-<li><p><strong>Use-After-Close:</strong> and we can call <code>writeString</code> on a <code>File</code> object that has already been closed:</p>
+<li><p><strong>Use-After-Close:</strong> and we can call
+<code>writeString</code> on a <code>File</code> object that has already
+been closed:</p>
 <pre><code>closeFile(file)
 writeString(file, &quot;Goodbye, world!&quot;);</code></pre>
 <p>And we can close the file handle after it has been closed:</p>
 <pre><code>closeFile(file);
 closeFile(file);</code></pre></li>
 </ol>
-<p>In a short linear program like this, we aren’t likely to make these mistakes. But when handles are stored in data structures and shuffled around, and the lifecycle calls are separated across time and space, these errors become more common.</p>
-<p>And they don’t just apply to files. Consider a database access API:</p>
+<p>In a short linear program like this, we aren’t likely to make these
+mistakes. But when handles are stored in data structures and shuffled
+around, and the lifecycle calls are separated across time and space,
+these errors become more common.</p>
+<p>And they don’t just apply to files. Consider a database access
+API:</p>
 <pre><code>type Db
 
 Db connect(String host)
@@ -388,7 +660,9 @@ Db connect(String host)
 Rows query(Db db, String query)
 
 void close(Db db)</code></pre>
-<p>Again: after calling <code>close</code> we can still call <code>query</code> and <code>close</code>. And we can also forget to call <code>close</code> at all.</p>
+<p>Again: after calling <code>close</code> we can still call
+<code>query</code> and <code>close</code>. And we can also forget to
+call <code>close</code> at all.</p>
 <p>And — crucially — consider this memory management API:</p>
 <pre><code>type Pointer&lt;T&gt;
 
@@ -399,76 +673,153 @@ T load(Pointer&lt;T&gt; ptr)
 void store(Pointer&lt;T&gt; ptr, T value)
 
 void free(Pointer&lt;T&gt; ptr)</code></pre>
-<p>Here, again, we can forget to call <code>free</code> after allocating a pointer, we can call <code>free</code> twice on the same pointer, and, more disastrously, we can call <code>load</code> and <code>store</code> on a pointer that has been freed.</p>
-<p>Everywhere we have <em>resources</em> — types with an associated lifecycle, where they must be created, used, and destroyed, in that order — we have the same kind of errors: forgetting to destroy a value, or using a value after it has been destroyed.</p>
-<p>In the context of memory management, pointer lifecycle errors are so disastrous they have their own names:</p>
+<p>Here, again, we can forget to call <code>free</code> after allocating
+a pointer, we can call <code>free</code> twice on the same pointer, and,
+more disastrously, we can call <code>load</code> and <code>store</code>
+on a pointer that has been freed.</p>
+<p>Everywhere we have <em>resources</em> — types with an associated
+lifecycle, where they must be created, used, and destroyed, in that
+order — we have the same kind of errors: forgetting to destroy a value,
+or using a value after it has been destroyed.</p>
+<p>In the context of memory management, pointer lifecycle errors are so
+disastrous they have their own names:</p>
 <ol type="1">
-<li><a href="https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory">Double free errors</a>.</li>
-<li><a href="https://owasp.org/www-community/vulnerabilities/Using_freed_memory">Use-after-free errors</a>.</li>
+<li><a
+href="https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory">Double
+free errors</a>.</li>
+<li><a
+href="https://owasp.org/www-community/vulnerabilities/Using_freed_memory">Use-after-free
+errors</a>.</li>
 </ol>
-<p>Naturally, computer scientists have attempted to attack these problems. The traditional approach is called <em>static analysis</em>: a group of PhD’s will write a program that goes through the source code and performs various checks and finds places where these errors may occur.</p>
-<p>Reams and reams of papers, conference proceedings, university slides, etc. have been written on the use of static analysis to catch these errors. But the problem with static analysis is threefold:</p>
+<p>Naturally, computer scientists have attempted to attack these
+problems. The traditional approach is called <em>static analysis</em>: a
+group of PhD’s will write a program that goes through the source code
+and performs various checks and finds places where these errors may
+occur.</p>
+<p>Reams and reams of papers, conference proceedings, university slides,
+etc. have been written on the use of static analysis to catch these
+errors. But the problem with static analysis is threefold:</p>
 <ol type="1">
-<li><p>It is a moving target. While type systems are relatively fixed — i.e., the type checking rules are the same across language versions — static analyzers tend to change with each version, so that in each newer version of the software you get more and more sophisticated heuristics.</p></li>
-<li><p>Like unit tests, it can usually show the <em>presence</em> of bugs, but not their <em>absence</em>. There may be false positives — code that is perfectly fine but that the static analyzer flags as incorrect — but more dangerous is the false negative, where the static analyzer returns an all clear on code that has a vulnerability.</p></li>
-<li><p>Static analysis is an opaque pile of heuristics. Because the analyses are always changing, the programmer is not expected to develop a mental model of the static analyzer, and to write code with that model in mind. Instead, they are expected to write the code they usually write, then throw the static analyzer at it and hope for the best.</p></li>
+<li><p>It is a moving target. While type systems are relatively fixed —
+i.e., the type checking rules are the same across language versions —
+static analyzers tend to change with each version, so that in each newer
+version of the software you get more and more sophisticated
+heuristics.</p></li>
+<li><p>Like unit tests, it can usually show the <em>presence</em> of
+bugs, but not their <em>absence</em>. There may be false positives —
+code that is perfectly fine but that the static analyzer flags as
+incorrect — but more dangerous is the false negative, where the static
+analyzer returns an all clear on code that has a vulnerability.</p></li>
+<li><p>Static analysis is an opaque pile of heuristics. Because the
+analyses are always changing, the programmer is not expected to develop
+a mental model of the static analyzer, and to write code with that model
+in mind. Instead, they are expected to write the code they usually
+write, then throw the static analyzer at it and hope for the
+best.</p></li>
 </ol>
-<p>What we want is a way to solve these problems that is <em>static</em> and <em>complete</em>. Static in that it is a fixed set of rules that you can learn once and remember, like how a type system works. <em>Complete</em> in that is has <em>no false negatives</em>, and <em>every</em> lifecycle error is caught.</p>
-<p>And, above all: we want it to be simple, so it can be wholly understood by the programmer working on it.</p>
+<p>What we want is a way to solve these problems that is <em>static</em>
+and <em>complete</em>. Static in that it is a fixed set of rules that
+you can learn once and remember, like how a type system works.
+<em>Complete</em> in that is has <em>no false negatives</em>, and
+<em>every</em> lifecycle error is caught.</p>
+<p>And, above all: we want it to be simple, so it can be wholly
+understood by the programmer working on it.</p>
 <p>So, to summarize our requirements:</p>
 <ol type="1">
-<li><p><strong>Correctness Requirement:</strong> We want a way to ensure that resources are used in the correct lifecycle.</p></li>
-<li><p><strong>Simplicity Requirement:</strong> We want that mechanism to be simple, that is, a programmer should be able to hold it in their head. This rules out complicated solutions involving theorem proving, SMT solvers, symbolic execution, etc.</p></li>
-<li><p><strong>Staticity Requirement:</strong> We want it to be a fixed set of rules and not an ever changing pile of heuristics.</p></li>
+<li><p><strong>Correctness Requirement:</strong> We want a way to ensure
+that resources are used in the correct lifecycle.</p></li>
+<li><p><strong>Simplicity Requirement:</strong> We want that mechanism
+to be simple, that is, a programmer should be able to hold it in their
+head. This rules out complicated solutions involving theorem proving,
+SMT solvers, symbolic execution, etc.</p></li>
+<li><p><strong>Staticity Requirement:</strong> We want it to be a fixed
+set of rules and not an ever changing pile of heuristics.</p></li>
 </ol>
-<p>All these goals are achievable: the solution is <em>linear types</em>.</p>
+<p>All these goals are achievable: the solution is <em>linear
+types</em>.</p>
 <h3 id="rationale-linear-intro-linear-types">Linear Types</h3>
-<p>This section describes what linear types are, how they provide the safety properties we want, and how we can relax some of the more onerous restrictions so as to increase programmer ergonomics while retaining safety.</p>
-<p>A <em>type</em> is a set of values that share some structure. A <em>linear type</em> is a type whose values can only be used once. This restriction may sound onerous (and unrelated to the problems we want to solve), but it isn’t.</p>
+<p>This section describes what linear types are, how they provide the
+safety properties we want, and how we can relax some of the more onerous
+restrictions so as to increase programmer ergonomics while retaining
+safety.</p>
+<p>A <em>type</em> is a set of values that share some structure. A
+<em>linear type</em> is a type whose values can only be used once. This
+restriction may sound onerous (and unrelated to the problems we want to
+solve), but it isn’t.</p>
 <p>A linear type system can be defined with just two rules:</p>
 <ol type="1">
-<li><p><strong>Linear Universe Rule:</strong> in a linear type system, the set of types is divided into two <em>universes</em>: the <em>free</em> universe, containing types which can be used any number of times (like booleans, machine sized integers, floats, structs containing free types, etc.); and the <em>linear</em> universe, containing linear types, which usually represent resources (pointers, file handles, database handles, etc.).</p>
+<li><p><strong>Linear Universe Rule:</strong> in a linear type system,
+the set of types is divided into two <em>universes</em>: the
+<em>free</em> universe, containing types which can be used any number of
+times (like booleans, machine sized integers, floats, structs containing
+free types, etc.); and the <em>linear</em> universe, containing linear
+types, which usually represent resources (pointers, file handles,
+database handles, etc.).</p>
 <p>Types enter the linear universe in one of two ways:</p>
 <ol type="1">
-<li><p>By fiat: a type can simply be declared linear, even though it only contains free types. We’ll see later why this is useful.</p>
+<li><p>By fiat: a type can simply be declared linear, even though it
+only contains free types. We’ll see later why this is useful.</p>
 <pre><code>// `LInt` is in the `Linear` universe,
 // even if `Int` is in the `Free` universe.
 type LInt: Linear = Int</code></pre></li>
-<li><p>By containment: linear types can be thought of as being “viral”. If a type contains a value of a linear type, it automatically becomes linear.</p>
-<p>So, if you have a linear type <code>T</code>, then a tuple <code>(a, b, T)</code> is linear, a struct like:</p>
+<li><p>By containment: linear types can be thought of as being “viral”.
+If a type contains a value of a linear type, it automatically becomes
+linear.</p>
+<p>So, if you have a linear type <code>T</code>, then a tuple
+<code>(a, b, T)</code> is linear, a struct like:</p>
 <pre><code>struct Ex {
     a: A;
     b: B;
     c: Pair&lt;T, A&gt;;
 }</code></pre>
-<p>is linear because the slot <code>c</code> contains a type which in turn contains <code>T</code>. A union or enum where one of the variants contains a linear type is, unsurprisingly, linear. You can’t sneak a linear type into a free type.</p></li>
+<p>is linear because the slot <code>c</code> contains a type which in
+turn contains <code>T</code>. A union or enum where one of the variants
+contains a linear type is, unsurprisingly, linear. You can’t sneak a
+linear type into a free type.</p></li>
 </ol>
-<p>The virality of linear types ensures that you can’t escape linearity by accident.</p></li>
-<li><p><strong>Use-Once Rule:</strong> a value of a linear type must be used once and only once. Not <em>can</em>: <em>must</em>. It cannot be used zero times. This can be enforced entirely at compile time through a very simple set of checks.</p>
-<p>To understand what “using” a linear value means, let’s look at some examples. Suppose you have a function <code>f</code> that returns a value of a linear type <code>L</code>.</p>
+<p>The virality of linear types ensures that you can’t escape linearity
+by accident.</p></li>
+<li><p><strong>Use-Once Rule:</strong> a value of a linear type must be
+used once and only once. Not <em>can</em>: <em>must</em>. It cannot be
+used zero times. This can be enforced entirely at compile time through a
+very simple set of checks.</p>
+<p>To understand what “using” a linear value means, let’s look at some
+examples. Suppose you have a function <code>f</code> that returns a
+value of a linear type <code>L</code>.</p>
 <p>Then, the following code:</p>
 <pre><code>{
     let x: L := f();
 }</code></pre>
-<p>is incorrect. <code>x</code> is a variable of a linear type, and it is used zero times. The compiler will complain that <code>x</code> is being silently discarded.</p>
+<p>is incorrect. <code>x</code> is a variable of a linear type, and it
+is used zero times. The compiler will complain that <code>x</code> is
+being silently discarded.</p>
 <p>Similarly, if you have:</p>
 <pre><code>{
     f();
 }</code></pre>
-<p>The compiler will complain that the return value of <code>f</code> is being silently discarded, which you can’t do to a linear type.</p>
+<p>The compiler will complain that the return value of <code>f</code> is
+being silently discarded, which you can’t do to a linear type.</p>
 <p>If you have:</p>
 <pre><code>{
     let x: L := f();
     g(x);
     h(x);
 }</code></pre>
-<p>The compiler will complain that <code>x</code> is being used twice: it is passed into <code>g</code>, at which point is it said to be <em>consumed</em>, but then it is passed into <code>h</code>, and that’s not allowed.</p>
-<p>This code, however, passes: <code>x</code> is used once and exactly once:</p>
+<p>The compiler will complain that <code>x</code> is being used twice:
+it is passed into <code>g</code>, at which point is it said to be
+<em>consumed</em>, but then it is passed into <code>h</code>, and that’s
+not allowed.</p>
+<p>This code, however, passes: <code>x</code> is used once and exactly
+once:</p>
 <pre><code>{
     let x: L := f();
     g(x);
 }</code></pre>
-<p>“Used” does not, however, mean “appears once in the code”. Consider how <code>if</code> statements work. The compiler will complain about the following code, because even though <code>x</code> appears only once in the source code, it is not being “used once”, rather it’s being used — how shall I put it? 0.5 times?:</p>
+<p>“Used” does not, however, mean “appears once in the code”. Consider
+how <code>if</code> statements work. The compiler will complain about
+the following code, because even though <code>x</code> appears only once
+in the source code, it is not being “used once”, rather it’s being used
+— how shall I put it? 0.5 times?:</p>
 <pre><code>{
     let x: L := f();
     if (cond) {
@@ -477,7 +828,8 @@ type LInt: Linear = Int</code></pre></li>
         // Do nothing.
     }
 }</code></pre>
-<p><code>x</code> is consumed in one branch but not the other, and the compiler isn’t happy. If we change the code to this:</p>
+<p><code>x</code> is consumed in one branch but not the other, and the
+compiler isn’t happy. If we change the code to this:</p>
 <pre><code>{
     let x: L := f();
     if (cond) {
@@ -486,7 +838,9 @@ type LInt: Linear = Int</code></pre></li>
         h(x);
     }
 }</code></pre>
-<p>Then we’re good. The rule here is that a variable of a linear type, defined outside an <code>if</code> statement, must be used either zero times in that statement, or exactly once in each branch.</p>
+<p>Then we’re good. The rule here is that a variable of a linear type,
+defined outside an <code>if</code> statement, must be used either zero
+times in that statement, or exactly once in each branch.</p>
 <p>A similar restriction applies to loops. We can’t do this:</p>
 <pre><code>{
     let x: L := f();
@@ -494,12 +848,22 @@ type LInt: Linear = Int</code></pre></li>
         g(x);
     }
 }</code></pre>
-<p>Because even though <code>x</code> appears once, it is <em>used</em> more than once: it is used once in each iteration. The rule here is that a variable of a linear type, defined outside a loop, cannot appear in the body of the loop.</p></li>
+<p>Because even though <code>x</code> appears once, it is <em>used</em>
+more than once: it is used once in each iteration. The rule here is that
+a variable of a linear type, defined outside a loop, cannot appear in
+the body of the loop.</p></li>
 </ol>
-<p>That’s it. That’s all there is to it. We have a fixed set of rules, and they’re so brief you can learn them in a few minutes. So we’re satisfying the simplicity and staticity requirements listed in the previous section.</p>
-<p>But do linear types satisfy the correctness requirement? In the next section, we’ll see how linear types make it possible to enforce that a value should be used in accordance to a lifecycle.</p>
+<p>That’s it. That’s all there is to it. We have a fixed set of rules,
+and they’re so brief you can learn them in a few minutes. So we’re
+satisfying the simplicity and staticity requirements listed in the
+previous section.</p>
+<p>But do linear types satisfy the correctness requirement? In the next
+section, we’ll see how linear types make it possible to enforce that a
+value should be used in accordance to a lifecycle.</p>
 <h3 id="rationale-linear-safety">Linear Types and Safety</h3>
-<p>Let’s consider a linear file system API. We’ll use a vaguely C++ like syntax, but linear types are denoted by an exclamation mark after their name.</p>
+<p>Let’s consider a linear file system API. We’ll use a vaguely C++ like
+syntax, but linear types are denoted by an exclamation mark after their
+name.</p>
 <p>The API looks like this:</p>
 <pre><code>type File!
 
@@ -508,52 +872,107 @@ File! openFile(String path)
 File! writeString(File! file, String content)
 
 void closeFile(File! file)</code></pre>
-<p>The <code>openFile</code> function is fairly normal: takes a path and returns a linear <code>File!</code> object.</p>
-<p><code>writeString</code> is where things are different: it takes a linear <code>File!</code> object (and consumes it), and a string, and it returns a “new” linear <code>File!</code> object. “New” is in quotes because it is a fresh linear value only from the perspective of the type system: it is still a handle to the same file. But don’t think about the implementation too much: we’ll look into how this is implemented later.</p>
-<p><code>closeFile</code> is the destructor for the <code>File!</code> type, and is the terminus of the lifecycle graph: a <code>File!</code> enters and does not leave, and the object is disposed of. Let’s see how linear types help us write safe code.</p>
+<p>The <code>openFile</code> function is fairly normal: takes a path and
+returns a linear <code>File!</code> object.</p>
+<p><code>writeString</code> is where things are different: it takes a
+linear <code>File!</code> object (and consumes it), and a string, and it
+returns a “new” linear <code>File!</code> object. “New” is in quotes
+because it is a fresh linear value only from the perspective of the type
+system: it is still a handle to the same file. But don’t think about the
+implementation too much: we’ll look into how this is implemented
+later.</p>
+<p><code>closeFile</code> is the destructor for the <code>File!</code>
+type, and is the terminus of the lifecycle graph: a <code>File!</code>
+enters and does not leave, and the object is disposed of. Let’s see how
+linear types help us write safe code.</p>
 <p>Can we leak a <code>File!</code> object? No:</p>
 <pre><code>let file: File! := openFile(&quot;sonnets.txt&quot;);
 // Do nothing.</code></pre>
-<p>The compiler will complain: the variable <code>file</code> is used zero times. Alternatively:</p>
+<p>The compiler will complain: the variable <code>file</code> is used
+zero times. Alternatively:</p>
 <pre><code>let file: File! := openFile(&quot;sonnets.txt&quot;);
 writeString(file, &quot;Devouring Time, blunt thou the lion’s paws, ...&quot;);</code></pre>
-<p>The return value of <code>writeString</code> is a linear <code>File!</code> object, and it is being silently discarded. The compiler will whine at us.</p>
+<p>The return value of <code>writeString</code> is a linear
+<code>File!</code> object, and it is being silently discarded. The
+compiler will whine at us.</p>
 <p>We can strike the “leak” transitions from the lifecycle graph:</p>
 <figure>
-<img src="/assets/spec/file-api-without-leaks.png" alt="" /><figcaption>A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four black arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’. There are two red arrows: one from ‘closeFile’ to ‘writeString’ labeled ‘use after close’, and one from ‘closeFile’ to itself labeled ‘double close’.</figcaption>
+<img src="/assets/spec/file-api-without-leaks.png"
+alt="A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four black arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’. There are two red arrows: one from ‘closeFile’ to ‘writeString’ labeled ‘use after close’, and one from ‘closeFile’ to itself labeled ‘double close’." />
+<figcaption aria-hidden="true">A graph with three nodes labeled
+‘openFile’, ‘writeString’, and ‘close File’. There are four black
+arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to
+‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to
+‘closeFile’. There are two red arrows: one from ‘closeFile’ to
+‘writeString’ labeled ‘use after close’, and one from ‘closeFile’ to
+itself labeled ‘double close’.</figcaption>
 </figure>
 <p>Can we close a file twice? No:</p>
 <pre><code>let file: File! := openFile(&quot;test.txt&quot;);
 closeFile(file);
 closeFile(file);</code></pre>
-<p>The compiler will complain that you’re trying to use a linear variable twice. So we can strike the “double close” erroneous transition from the lifecycle graph:</p>
+<p>The compiler will complain that you’re trying to use a linear
+variable twice. So we can strike the “double close” erroneous transition
+from the lifecycle graph:</p>
 <figure>
-<img src="/assets/spec/file-api-without-leaks-and-double-close.png" alt="" /><figcaption>A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four black arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’. There is one red arrow: from ‘closeFile’ to ‘writeString’ labeled ‘use after close’.</figcaption>
+<img src="/assets/spec/file-api-without-leaks-and-double-close.png"
+alt="A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four black arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’. There is one red arrow: from ‘closeFile’ to ‘writeString’ labeled ‘use after close’." />
+<figcaption aria-hidden="true">A graph with three nodes labeled
+‘openFile’, ‘writeString’, and ‘close File’. There are four black
+arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to
+‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to
+‘closeFile’. There is one red arrow: from ‘closeFile’ to ‘writeString’
+labeled ‘use after close’.</figcaption>
 </figure>
-<p>And you can see where this is going. Can we write to a file after closing it? No:</p>
+<p>And you can see where this is going. Can we write to a file after
+closing it? No:</p>
 <pre><code>let file: File! := openFile(&quot;test.txt&quot;);
 closeFile(file);
 let file2: File! := writeString(file, &quot;Doing some mischief.&quot;);</code></pre>
-<p>The compiler will, again, complain that we’re consuming <code>file</code> twice. So we can strike the “use after close” transition from the lifecycle graph:</p>
+<p>The compiler will, again, complain that we’re consuming
+<code>file</code> twice. So we can strike the “use after close”
+transition from the lifecycle graph:</p>
 <figure>
-<img src="/assets/spec/file-api.png" alt="" /><figcaption>A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’.</figcaption>
+<img src="/assets/spec/file-api.png"
+alt="A graph with three nodes labeled ‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from ‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from ‘writeString’ to itself, and from ‘writeString’ to ‘closeFile’." />
+<figcaption aria-hidden="true">A graph with three nodes labeled
+‘openFile’, ‘writeString’, and ‘close File’. There are four arrows: from
+‘openFile’ to ‘writeString’, from ‘openFile’ to ‘closeFile’, from
+‘writeString’ to itself, and from ‘writeString’ to
+‘closeFile’.</figcaption>
 </figure>
-<p>And we have come full circle: the lifecycle that the compiler enforces is exactly, one-to-one, the lifecycle that we intended.</p>
-<p>There is, ultimately, one and only one way to use this API such that the compiler doesn’t complain:</p>
+<p>And we have come full circle: the lifecycle that the compiler
+enforces is exactly, one-to-one, the lifecycle that we intended.</p>
+<p>There is, ultimately, one and only one way to use this API such that
+the compiler doesn’t complain:</p>
 <pre><code>let f: File! := openFile(&quot;rilke.txt&quot;);
 let f_1: File! := writeString(f, &quot;We cannot know his legendary head\n&quot;);
 let f_2: File! := writeString(f_1, &quot;with eyes like ripening fruit. And yet his torso\n&quot;);
 ...
 let f_15: File! := writeString(f_14, &quot;You must change your life.&quot;);
 closeFile(f_15);</code></pre>
-<p>Note how the file value is “threaded” through the code, and each linear variable is used exactly once.</p>
-<p>And now we are three for three with the requirements we outlined in the previous section:</p>
+<p>Note how the file value is “threaded” through the code, and each
+linear variable is used exactly once.</p>
+<p>And now we are three for three with the requirements we outlined in
+the previous section:</p>
 <ol type="1">
-<li><p><strong>Correctness Requirement:</strong> Is it correct? Yes: linear types allow us to define APIs in such a way that the compiler enforces the lifecycle perfectly.</p></li>
-<li><p><strong>Simplicity Requirement:</strong> Is it simple? Yes: the type system rules fit in a napkin. There’s no need to use an SMT solver, or to prove theorems about the code, or do symbolic execution and explore the state space of the program. The linearity checks are simple: we go over the code and count the number of times a variable appears, taking care to handle loops and <code>if</code> statements correctly. And also we ensure that linear values can’t be discarded silently.</p></li>
-<li><p><strong>Staticity Requirement:</strong> Is it an ever-growing, ever-changing pile of heuristics? No: it is a fixed set of rules. Learn it once and use it forever.</p></li>
+<li><p><strong>Correctness Requirement:</strong> Is it correct? Yes:
+linear types allow us to define APIs in such a way that the compiler
+enforces the lifecycle perfectly.</p></li>
+<li><p><strong>Simplicity Requirement:</strong> Is it simple? Yes: the
+type system rules fit in a napkin. There’s no need to use an SMT solver,
+or to prove theorems about the code, or do symbolic execution and
+explore the state space of the program. The linearity checks are simple:
+we go over the code and count the number of times a variable appears,
+taking care to handle loops and <code>if</code> statements correctly.
+And also we ensure that linear values can’t be discarded
+silently.</p></li>
+<li><p><strong>Staticity Requirement:</strong> Is it an ever-growing,
+ever-changing pile of heuristics? No: it is a fixed set of rules. Learn
+it once and use it forever.</p></li>
 </ol>
-<p>And does this solution generalize? Let’s consider a linear database API:</p>
+<p>And does this solution generalize? Let’s consider a linear database
+API:</p>
 <pre><code>type Db!
 
 Db! connect(String host)
@@ -561,37 +980,54 @@ Db! connect(String host)
 Pair&lt;Db!, Rows&gt; query(Db! db, String query)
 
 void close(Db! db)</code></pre>
-<p>This one’s a bit more involved: the <code>query</code> function has to return a tuple containing both the new <code>Db!</code> handle, and the result set.</p>
+<p>This one’s a bit more involved: the <code>query</code> function has
+to return a tuple containing both the new <code>Db!</code> handle, and
+the result set.</p>
 <p>Again: we can’t leak a database handle:</p>
 <pre><code>let db: Db! := connect(&quot;localhost&quot;);
 // Do nothing.</code></pre>
-<p>Because the compiler will point out that <code>db</code> is never consumed. We can’t <code>close</code> a database handle twice:</p>
+<p>Because the compiler will point out that <code>db</code> is never
+consumed. We can’t <code>close</code> a database handle twice:</p>
 <pre><code>let db: Db! := connect(&quot;localhost&quot;);
 close(db);
 close(db); // error: `db` consumed again.</code></pre>
-<p>Because <code>db</code> is used twice. Analogously, we can’t query a database once it’s closed:</p>
+<p>Because <code>db</code> is used twice. Analogously, we can’t query a
+database once it’s closed:</p>
 <pre><code>let db: Db! := connect(&quot;localhost&quot;);
 close(db);
 let (db1, rows): Pair&lt;Db!, Rows&gt; := query(db, &quot;SELECT ...&quot;);
 close(db); // error: `db` consumed again.</code></pre>
-<p>For the same reason. The only way to use the database correctly is:</p>
+<p>For the same reason. The only way to use the database correctly
+is:</p>
 <pre><code>let db: Db! := connect(&quot;localhost&quot;);
 let (db1, rows): Pair&lt;Db!, Rows&gt; := query(db, &quot;SELECT ...&quot;);
 // Iterate over the rows or some such.
 close(db1);</code></pre>
-<p>What about manual memory management? Can we make it safe? Let’s consider a linear pointer API, but first, we have to introduce some new notation. When you have a generic type with generic type parameters, in a regular language you might declare it like:</p>
+<p>What about manual memory management? Can we make it safe? Let’s
+consider a linear pointer API, but first, we have to introduce some new
+notation. When you have a generic type with generic type parameters, in
+a regular language you might declare it like:</p>
 <pre><code>type T&lt;A, B, C&gt;</code></pre>
-<p>Here, we also have to specify which universe the parameters and the resulting type belong to. Rember: there are two universes: free and linear. So for example we can write:</p>
+<p>Here, we also have to specify which universe the parameters and the
+resulting type belong to. Rember: there are two universes: free and
+linear. So for example we can write:</p>
 <pre><code>type T&lt;A: Free, B: Free&gt;: Free
 type U!&lt;A: Linear&gt;: Linear</code></pre>
-<p>But sometimes we want a generic type to accept type arguments from any universe. In that case, we use <code>Type</code>:</p>
+<p>But sometimes we want a generic type to accept type arguments from
+any universe. In that case, we use <code>Type</code>:</p>
 <pre><code>type Pair&lt;L: Type, R: Type&gt;: Type;</code></pre>
-<p>This basically means: the type parameters <code>L</code> and <code>R</code> can be filled with types from either universe, and the universe that <code>Pair</code> belongs to is determined by said arguments:</p>
+<p>This basically means: the type parameters <code>L</code> and
+<code>R</code> can be filled with types from either universe, and the
+universe that <code>Pair</code> belongs to is determined by said
+arguments:</p>
 <ol type="1">
-<li>If <code>A</code> and <code>B</code> are both <code>Free</code>, then <code>Pair</code> is <code>Free</code>.</li>
-<li>If either one of <code>A</code> and <code>B</code> are <code>Linear</code>, then <code>Pair</code> is <code>Linear</code>.</li>
+<li>If <code>A</code> and <code>B</code> are both <code>Free</code>,
+then <code>Pair</code> is <code>Free</code>.</li>
+<li>If either one of <code>A</code> and <code>B</code> are
+<code>Linear</code>, then <code>Pair</code> is <code>Linear</code>.</li>
 </ol>
-<p>Now that we’re being explicit about universes, we can drop the exclamation mark notation.</p>
+<p>Now that we’re being explicit about universes, we can drop the
+exclamation mark notation.</p>
 <p>Here’s the linear pointer API:</p>
 <pre><code>type Pointer&lt;T: Type&gt;: Linear;
 
@@ -606,56 +1042,113 @@ Pair&lt;Pointer&lt;T&gt;, T&gt; load(Pointer&lt;T&gt; ptr)
 
 generic &lt;T: Free&gt;
 Pointer&lt;T&gt; store(Pointer&lt;T&gt; ptr, T value)</code></pre>
-<p>This is more involved than previous examples, and uses new notation, so let’s break it down declaration by declaration.</p>
+<p>This is more involved than previous examples, and uses new notation,
+so let’s break it down declaration by declaration.</p>
 <ol type="1">
-<li><p>First, we declare the <code>Pointer</code> type as a generic type that takes a parameter from any universe, and belongs to the <code>Linear</code> universe by fiat. That is: even if <code>T</code> is <code>Free</code>, <code>Pointer&lt;T&gt;</code> will be <code>Linear</code>.</p>
+<li><p>First, we declare the <code>Pointer</code> type as a generic type
+that takes a parameter from any universe, and belongs to the
+<code>Linear</code> universe by fiat. That is: even if <code>T</code> is
+<code>Free</code>, <code>Pointer&lt;T&gt;</code> will be
+<code>Linear</code>.</p>
 <pre><code>type Pointer&lt;T: Type&gt;: Linear;</code></pre></li>
-<li><p>Second, we define a generic function <code>allocate</code>, that takes a value from either universe, allocates memory for it, and returns a linear pointer to it.</p>
+<li><p>Second, we define a generic function <code>allocate</code>, that
+takes a value from either universe, allocates memory for it, and returns
+a linear pointer to it.</p>
 <pre><code>generic &lt;T: Type&gt;
 Pointer&lt;T&gt; allocate(T value)</code></pre></li>
-<li><p>Third, we define a slightly unusual <code>deallocate</code> function: rather than returning <code>void</code>, it takes a pointer, dereferences it, deallocates the memory, and returns the dereferenced value:</p>
+<li><p>Third, we define a slightly unusual <code>deallocate</code>
+function: rather than returning <code>void</code>, it takes a pointer,
+dereferences it, deallocates the memory, and returns the dereferenced
+value:</p>
 <pre><code>generic &lt;T: Type&gt;
 T deallocate(Pointer!&lt;T&gt; ptr)</code></pre></li>
-<li><p>Fourth, we define a generic function specifically for pointers that contain free values: it takes a pointer, dereferences it, and returns a tuple with both the pointer and the dereferenced free value.</p>
+<li><p>Fourth, we define a generic function specifically for pointers
+that contain free values: it takes a pointer, dereferences it, and
+returns a tuple with both the pointer and the dereferenced free
+value.</p>
 <pre><code>generic &lt;T: Free&gt;
 (Pointer&lt;T&gt;, T) load(Pointer&lt;T&gt; ptr)</code></pre>
-<p>Why does <code>T</code> have to belong to the <code>Free</code> universe? Because otherwise we could write code like this:</p>
+<p>Why does <code>T</code> have to belong to the <code>Free</code>
+universe? Because otherwise we could write code like this:</p>
 <pre><code>// Suppose that `L` is a linear type.
 let p: Pointer&lt;L&gt; := allocate(...);
 let (p2, val): Pair&lt;Pointer&lt;L&gt;, L&gt; := load(p);
 let (p3, val2): Pair&lt;Pointer&lt;L&gt;, L&gt; := load(p2);</code></pre>
-<p>Here, we’ve allocated a pointer to a linear value, but we’ve loaded it from memory twice, effectively duplicating it. This obviously should not be allowed. So the type parameter <code>T</code> is constrained to take only values of the <code>Free</code> universe, which can be copied freely any number of times.</p></li>
-<li><p>Fifth, we define a generic function, again for pointers that contain free values. It takes a pointer and a free value, and stores that value in the memory allocated by the pointer, and returns the pointer again for reuse:</p>
+<p>Here, we’ve allocated a pointer to a linear value, but we’ve loaded
+it from memory twice, effectively duplicating it. This obviously should
+not be allowed. So the type parameter <code>T</code> is constrained to
+take only values of the <code>Free</code> universe, which can be copied
+freely any number of times.</p></li>
+<li><p>Fifth, we define a generic function, again for pointers that
+contain free values. It takes a pointer and a free value, and stores
+that value in the memory allocated by the pointer, and returns the
+pointer again for reuse:</p>
 <pre><code>generic &lt;T: Free&gt;
 Pointer&lt;T&gt; store(Pointer&lt;T&gt; ptr, T value)</code></pre>
-<p>Again: why can’t this function be defined for linear values? Because then we could write:</p>
+<p>Again: why can’t this function be defined for linear values? Because
+then we could write:</p>
 <pre><code>// Suppose `L` is a linear type, and `a` and b`
 // are variables of type `L`.
 let p1: Pointer&lt;L&gt; := allocate(a);
 let p2: Pointer&lt;L&gt; := store(p1, b);
 let l: L := deallocate(p2);</code></pre>
-<p>What happens to <code>a</code>? It is overwritten by <code>b</code> and lost. For values in the <code>Free</code> universe this is no problem: who cares if a byte is overwritten? But we can’t overwrite linear values – like database handles and such – because the they would be leaked.</p></li>
+<p>What happens to <code>a</code>? It is overwritten by <code>b</code>
+and lost. For values in the <code>Free</code> universe this is no
+problem: who cares if a byte is overwritten? But we can’t overwrite
+linear values – like database handles and such – because the they would
+be leaked.</p></li>
 </ol>
-<p>It is trivial to verify the safety properties. We can’t leak memory, we can’t deallocate twice, and we can’t read or write from and to a pointer after it has been deallocated.</p>
-<h3 id="rationale-linear-what-linear-types-provide">What Linear Types Provide</h3>
+<p>It is trivial to verify the safety properties. We can’t leak memory,
+we can’t deallocate twice, and we can’t read or write from and to a
+pointer after it has been deallocated.</p>
+<h3 id="rationale-linear-what-linear-types-provide">What Linear Types
+Provide</h3>
 <p>Linear types give us the following benefits:</p>
 <ol type="1">
-<li><p>Manual memory management without memory leaks, use-after-<code>free</code>, double <code>free</code> errors, garbage collection, or any runtime overhead in either time or space other than having an allocator available.</p></li>
-<li><p>More generally, we can manage <em>any</em> resource (file handles, socket handles, etc.) that has a lifecycle in a way that prevents:</p>
+<li><p>Manual memory management without memory leaks,
+use-after-<code>free</code>, double <code>free</code> errors, garbage
+collection, or any runtime overhead in either time or space other than
+having an allocator available.</p></li>
+<li><p>More generally, we can manage <em>any</em> resource (file
+handles, socket handles, etc.) that has a lifecycle in a way that
+prevents:</p>
 <ol type="1">
-<li>Forgetting to dispose of that resource (e.g.: leaving a file handle open).</li>
-<li>Disposing of the resource twice (e.g.: trying to free a pointer twice).</li>
-<li>Using that resource after it has been disposed of (e.g.: reading from a closed socket).</li>
+<li>Forgetting to dispose of that resource (e.g.: leaving a file handle
+open).</li>
+<li>Disposing of the resource twice (e.g.: trying to free a pointer
+twice).</li>
+<li>Using that resource after it has been disposed of (e.g.: reading
+from a closed socket).</li>
 </ol>
-<p>All of these errors are prevented <em>statically</em>, again without runtime overhead.</p></li>
-<li><p>In-place optimization: the APIs we have looked at resemble functional code. We write code “as if” we were creating and returning new objects with each call, while doing extensive mutations under the hood. This gives us the benefits of functional programming (referential transparency and equational reasoning) with the performance of imperative code that mutates data wildly.</p></li>
-<li><p>Safe concurrency. A value of a linear type, by definition, has only one owner: we cannot duplicate it, therefore, we cannot have multiple owners across threads. So imperative mutation is safe, since we know that no other thread can write to our linear value while we work with it.</p></li>
-<li><p>Capability-based security: suppose we want to lock down access to the terminal. We want there to be only one thread that can write to the terminal at a time. Furthermore, code that wants to write to the terminal needs permission to do so.</p>
-<p>We can do this with linear types, by having a linear <code>Terminal</code> type that represents the capability of using the terminal. Functions that read and write from and to the terminal need to take a <code>Terminal</code> instance and return it. We’ll discuss capability based security in greater detail in a future section.</p></li>
+<p>All of these errors are prevented <em>statically</em>, again without
+runtime overhead.</p></li>
+<li><p>In-place optimization: the APIs we have looked at resemble
+functional code. We write code “as if” we were creating and returning
+new objects with each call, while doing extensive mutations under the
+hood. This gives us the benefits of functional programming (referential
+transparency and equational reasoning) with the performance of
+imperative code that mutates data wildly.</p></li>
+<li><p>Safe concurrency. A value of a linear type, by definition, has
+only one owner: we cannot duplicate it, therefore, we cannot have
+multiple owners across threads. So imperative mutation is safe, since we
+know that no other thread can write to our linear value while we work
+with it.</p></li>
+<li><p>Capability-based security: suppose we want to lock down access to
+the terminal. We want there to be only one thread that can write to the
+terminal at a time. Furthermore, code that wants to write to the
+terminal needs permission to do so.</p>
+<p>We can do this with linear types, by having a linear
+<code>Terminal</code> type that represents the capability of using the
+terminal. Functions that read and write from and to the terminal need to
+take a <code>Terminal</code> instance and return it. We’ll discuss
+capability based security in greater detail in a future
+section.</p></li>
 </ol>
 <h3 id="rationale-linear-trust-boundary">The Trust Boundary</h3>
-<p>So far we have only seen the interfaces of linear APIs. What about the implementations?</p>
-<p>Here’s the linear file access API, using the universe notation instead of the exclamation mark notation to indicate linear types:</p>
+<p>So far we have only seen the interfaces of linear APIs. What about
+the implementations?</p>
+<p>Here’s the linear file access API, using the universe notation
+instead of the exclamation mark notation to indicate linear types:</p>
 <pre><code>type File: Linear
 
 File openFile(String path)
@@ -663,8 +1156,12 @@ File openFile(String path)
 File writeString(File file, String content)
 
 void closeFile(File file)</code></pre>
-<p>How does <code>writeString</code> respect linearity? Clearly, it is consuming a <code>File</code> handle, then returning it again. Does it internally close and reopen the file handle?</p>
-<p>The answer involves the concept of a <em>trust boundary</em>: inside the <code>File</code> type is a plain old fashioned (unrestricted, non-linear) file handle, like so:</p>
+<p>How does <code>writeString</code> respect linearity? Clearly, it is
+consuming a <code>File</code> handle, then returning it again. Does it
+internally close and reopen the file handle?</p>
+<p>The answer involves the concept of a <em>trust boundary</em>: inside
+the <code>File</code> type is a plain old fashioned (unrestricted,
+non-linear) file handle, like so:</p>
 <pre><code>struct File: Linear {
   handle: int;
 }</code></pre>
@@ -675,7 +1172,9 @@ File openFile(String path) {
     let handle: int = fopen(as_c_string(filename), &quot;r&quot;);
     return File(handle =&gt; ptr);
 }</code></pre>
-<p><code>openFile</code> calls <code>fopen</code>, which returns a file handle as an ordinary, free integer. Then we wrap it in a nice linear type and return it to the client.</p>
+<p><code>openFile</code> calls <code>fopen</code>, which returns a file
+handle as an ordinary, free integer. Then we wrap it in a nice linear
+type and return it to the client.</p>
 <p>Write string is where the magic happens:</p>
 <pre><code>extern int fputs(char* string, int fp)
 
@@ -684,8 +1183,10 @@ File writeString(File file, String content) {
   fputs(as_c_string(content), handle);
   return File(handle =&gt; ptr);
 }</code></pre>
-<p>The <code>let</code> statement uses destructuring syntax: it “explodes” a linear struct into a set of variables.</p>
-<p>Why do we need destructuring? Imagine if we had a struct with two linear fields:</p>
+<p>The <code>let</code> statement uses destructuring syntax: it
+“explodes” a linear struct into a set of variables.</p>
+<p>Why do we need destructuring? Imagine if we had a struct with two
+linear fields:</p>
 <pre><code>struct Pair {
   x: L1;
   y: L2;
@@ -693,10 +1194,23 @@ File writeString(File file, String content) {
 <p>And we wanted to write code like:</p>
 <pre><code>let p: Pair := make_pair();
 let x: L1 := p.x;</code></pre>
-<p>This is a big problem. <code>p</code> is being consumed by the <code>p.x</code> expression. But what happens to the <code>y</code> field in the <code>p</code> struct? It is leaked: we can’t afterwards write <code>p.y</code> because <code>p</code> has been consumed.</p>
-<p>Austral has special rules around accessing the fields of a struct to prevent this kind of situation. And the destructuring syntax we’re using allows us to take a struct, dismantle it into its constituent fields (linear or otherwise), then transform the values of those fields and/or put them back together.</p>
-<p>This is what we’re doing in <code>openFile</code>: we break up the <code>File</code> value into its constituent fields (here just <code>handle</code>), which consumes it. Then we call <code>fputs</code> on the non-linear handle, then, we construct a new instance of <code>File</code> that contains the unchanged file handle.</p>
-<p>From the compiler’s perspective, the <code>File</code> that goes in is distinct from the <code>File</code> that goes out and linearity is respected. Internally, the non-linear handle is the same.</p>
+<p>This is a big problem. <code>p</code> is being consumed by the
+<code>p.x</code> expression. But what happens to the <code>y</code>
+field in the <code>p</code> struct? It is leaked: we can’t afterwards
+write <code>p.y</code> because <code>p</code> has been consumed.</p>
+<p>Austral has special rules around accessing the fields of a struct to
+prevent this kind of situation. And the destructuring syntax we’re using
+allows us to take a struct, dismantle it into its constituent fields
+(linear or otherwise), then transform the values of those fields and/or
+put them back together.</p>
+<p>This is what we’re doing in <code>openFile</code>: we break up the
+<code>File</code> value into its constituent fields (here just
+<code>handle</code>), which consumes it. Then we call <code>fputs</code>
+on the non-linear handle, then, we construct a new instance of
+<code>File</code> that contains the unchanged file handle.</p>
+<p>From the compiler’s perspective, the <code>File</code> that goes in
+is distinct from the <code>File</code> that goes out and linearity is
+respected. Internally, the non-linear handle is the same.</p>
 <p>Finally, <code>closeFile</code> looks like this:</p>
 <pre><code>extern int fclose(int fp)
 
@@ -704,360 +1218,975 @@ void closeFile(File file) {
   let { handle: int } := file;
   fclose(handle);
 }</code></pre>
-<p>The <code>file</code> variable is consumed by being destructured. Then we call <code>fclose</code> on the underlying file handle.</p>
-<p>And there you have it: linear interface, non-linear interior. Inside the trust boundary, there is a light amount of unsafe FFI code (ideally, carefully vetted and tested). Outside, there is a linear interface, which can only be used correctly.</p>
+<p>The <code>file</code> variable is consumed by being destructured.
+Then we call <code>fclose</code> on the underlying file handle.</p>
+<p>And there you have it: linear interface, non-linear interior. Inside
+the trust boundary, there is a light amount of unsafe FFI code (ideally,
+carefully vetted and tested). Outside, there is a linear interface,
+which can only be used correctly.</p>
 <h3 id="rationale-linear-affine-types">Affine Types</h3>
-<p>Affine types are a “weakening” of linear types. Where linear types are “use exactly once”, affine types are “use <em>at most</em> once”. Values can be silently discarded.</p>
-<p>This requires a way to associate destructors to affine types. Then, at the end of a block, the compiler will look around for unconsumed affine values, and insert calls to their destructors.</p>
+<p>Affine types are a “weakening” of linear types. Where linear types
+are “use exactly once”, affine types are “use <em>at most</em> once”.
+Values can be silently discarded.</p>
+<p>This requires a way to associate destructors to affine types. Then,
+at the end of a block, the compiler will look around for unconsumed
+affine values, and insert calls to their destructors.</p>
 <p>There are two benefits to affine types:</p>
 <ol type="1">
-<li><p>First, by using implicit destructors, the code is less verbose.</p></li>
-<li><p>Secondly (and this will be expanded upon in the next section), affine types are compatible with traditional (C++ or Java-style) exception handling, while linear types are not.</p></li>
+<li><p>First, by using implicit destructors, the code is less
+verbose.</p></li>
+<li><p>Secondly (and this will be expanded upon in the next section),
+affine types are compatible with traditional (C++ or Java-style)
+exception handling, while linear types are not.</p></li>
 </ol>
 <p>But there are downsides:</p>
 <ol type="1">
-<li><p>Sometimes, you <em>don’t</em> want values to be silently discarded.</p></li>
-<li><p>There are implicit function calls (destructor calls are inserted by the compiler at the end of blocks).</p></li>
-<li><p>Exception handling involves a great deal of complexity, and is not immune to e.g. the “double throw” problem.</p></li>
+<li><p>Sometimes, you <em>don’t</em> want values to be silently
+discarded.</p></li>
+<li><p>There are implicit function calls (destructor calls are inserted
+by the compiler at the end of blocks).</p></li>
+<li><p>Exception handling involves a great deal of complexity, and is
+not immune to e.g. the “double throw” problem.</p></li>
 </ol>
 <h3 id="rationale-linear-borrowing">Borrowing</h3>
-<p>Returning tuples from every function and threading linear values through the code is very verbose.</p>
-<p>It is also often a violation of the principle of least privilege: linear values, in a sense, have “uniform permissions”. If you have a linear value, you can destroy it. Consider the linear pointer API described above: the <code>load</code> function could internally deallocate the pointer and allocate it again.</p>
-<p>We wouldn’t <em>expect</em> that to happen, but the whole point is to be defensive. We want the language to give us some guarantees: if a function should only be allowed to read from a linear value, but not deallocate it or mutate its interior, we want a way to represent that.</p>
-<p><em>Borrowing</em> is stolen lock, stock, and barrel from Rust. It advanced programming ergonomics by allowing us to treat a linear value as free within a delineated context. And it allows us to degrade permissions: we can pass read-only references to a linear value to functions that should only be able to read from that value, we can pass mutable references to a linear value to functions that should only be able to read from, and mutate, that value, without destroying it. Passing the linear value itself is the highest level of permissions: it allows the receiving function to do anything whatever with that value, by taking complete ownership of it.</p>
+<p>Returning tuples from every function and threading linear values
+through the code is very verbose.</p>
+<p>It is also often a violation of the principle of least privilege:
+linear values, in a sense, have “uniform permissions”. If you have a
+linear value, you can destroy it. Consider the linear pointer API
+described above: the <code>load</code> function could internally
+deallocate the pointer and allocate it again.</p>
+<p>We wouldn’t <em>expect</em> that to happen, but the whole point is to
+be defensive. We want the language to give us some guarantees: if a
+function should only be allowed to read from a linear value, but not
+deallocate it or mutate its interior, we want a way to represent
+that.</p>
+<p><em>Borrowing</em> is stolen lock, stock, and barrel from Rust. It
+advanced programming ergonomics by allowing us to treat a linear value
+as free within a delineated context. And it allows us to degrade
+permissions: we can pass read-only references to a linear value to
+functions that should only be able to read from that value, we can pass
+mutable references to a linear value to functions that should only be
+able to read from, and mutate, that value, without destroying it.
+Passing the linear value itself is the highest level of permissions: it
+allows the receiving function to do anything whatever with that value,
+by taking complete ownership of it.</p>
 <h3 id="rationale-linear-cutting-room-floor">The Cutting Room Floor</h3>
-<p>Universes are not the only way to implement linear types. There are three ways:</p>
+<p>Universes are not the only way to implement linear types. There are
+three ways:</p>
 <ol type="1">
-<li><p><strong>Linearity via arrows</strong>, as in the linear types extension of the GHC compiler for Haskell. This is the closest to Girard’s linear logic.</p></li>
-<li><p><strong>Linearity via kinds</strong>, which involves partitioning the set of types into two universes: a universe of unrestricted values which can be copied freely, such as integers, and a universe of restricted or linear types.</p></li>
-<li><p><strong>Rust’s approach</strong>, which is a sophisticated, fine-grained ownership tracking scheme.</p></li>
+<li><p><strong>Linearity via arrows</strong>, as in the linear types
+extension of the GHC compiler for Haskell. This is the closest to
+Girard’s linear logic.</p></li>
+<li><p><strong>Linearity via kinds</strong>, which involves partitioning
+the set of types into two universes: a universe of unrestricted values
+which can be copied freely, such as integers, and a universe of
+restricted or linear types.</p></li>
+<li><p><strong>Rust’s approach</strong>, which is a sophisticated,
+fine-grained ownership tracking scheme.</p></li>
 </ol>
-<p>In my opinion, linearity via arrows is best suited to an ML family language with single-parameter functions.</p>
-<p>Rust’s ownership tracking scheme allows programmers to write code that looks quite ordinary, frequently using values multiple times, while retaining “linear-like” properties. Ordinarily the restrictions show up when compilation fails.</p>
-<p>The Rust approach prioritizes programmer ergonomics, but it has a downside: the ownership tracking scheme is not a fixed algorithm that is set in stone in a standards document, which programmers are expected to read in order to write code. Rather, it is closer to static analysis in that it is a collection of rules, which evolve with the language, generally in the direction of improving ergonomics and allowing programmers to focus on the problem at hand rather than bending the code to fit the ownership scheme. Consequently, Rust programmers often describe a learning curve with a period of “fighting the borrow checker”, until they become used to the rules.</p>
-<p>Compare this with type checking algorithms: type checking is a simple, inductive process, so much so that programmers effectively run the algorithm while reading code to understand how it behaves. It often does not need documenting because it is obvious whether or not two types are equal or compatible, and the “warts” are generally in the area of implicit integer or float type conversions in arithmetic, and subtyping where present.</p>
+<p>In my opinion, linearity via arrows is best suited to an ML family
+language with single-parameter functions.</p>
+<p>Rust’s ownership tracking scheme allows programmers to write code
+that looks quite ordinary, frequently using values multiple times, while
+retaining “linear-like” properties. Ordinarily the restrictions show up
+when compilation fails.</p>
+<p>The Rust approach prioritizes programmer ergonomics, but it has a
+downside: the ownership tracking scheme is not a fixed algorithm that is
+set in stone in a standards document, which programmers are expected to
+read in order to write code. Rather, it is closer to static analysis in
+that it is a collection of rules, which evolve with the language,
+generally in the direction of improving ergonomics and allowing
+programmers to focus on the problem at hand rather than bending the code
+to fit the ownership scheme. Consequently, Rust programmers often
+describe a learning curve with a period of “fighting the borrow
+checker”, until they become used to the rules.</p>
+<p>Compare this with type checking algorithms: type checking is a
+simple, inductive process, so much so that programmers effectively run
+the algorithm while reading code to understand how it behaves. It often
+does not need documenting because it is obvious whether or not two types
+are equal or compatible, and the “warts” are generally in the area of
+implicit integer or float type conversions in arithmetic, and subtyping
+where present.</p>
 <p>There are many good reasons to prefer the Rust approach:</p>
 <ol type="1">
-<li><p>Programmers care a great deal about ergonomics. The <a href="https://en.wikipedia.org/wiki/Dangling_else">dangling else</a> is a feature of C syntax that has caused many security vulnerabilities. Try taking this away from programmers: they will kick and scream about the six bytes they’re saving on each <code>if</code> statement.</p></li>
-<li><p>Allowing programmers to write code that they’re used to helps with onboarding new users. It is generally not realistic to tell programmers to “read the spec” to learn a new language.</p></li>
-<li><p>By putting the complexity in the language, application code becomes simpler: programmers can focus on solving the problem at hand, and the compiler, ever helpful, will do its best to “prove around it”, that is, the compiler bends to the programmer’s code and tries to interpret it as best it can, rather than the programmer bending to the language’s rules.</p></li>
-<li><p>Since destructors are automatically inserted, the code is less verbose.</p></li>
-<li><p>Finally, Rust’s approach is compatible with exception handling, which the language provides: panics unwind the stack and call destructors automatically. Austral, because of its emphasis on implementation simplicty, has <em>much</em> more verbose code around error handling.</p></li>
+<li><p>Programmers care a great deal about ergonomics. The <a
+href="https://en.wikipedia.org/wiki/Dangling_else">dangling else</a> is
+a feature of C syntax that has caused many security vulnerabilities. Try
+taking this away from programmers: they will kick and scream about the
+six bytes they’re saving on each <code>if</code> statement.</p></li>
+<li><p>Allowing programmers to write code that they’re used to helps
+with onboarding new users. It is generally not realistic to tell
+programmers to “read the spec” to learn a new language.</p></li>
+<li><p>By putting the complexity in the language, application code
+becomes simpler: programmers can focus on solving the problem at hand,
+and the compiler, ever helpful, will do its best to “prove around it”,
+that is, the compiler bends to the programmer’s code and tries to
+interpret it as best it can, rather than the programmer bending to the
+language’s rules.</p></li>
+<li><p>Since destructors are automatically inserted, the code is less
+verbose.</p></li>
+<li><p>Finally, Rust’s approach is compatible with exception handling,
+which the language provides: panics unwind the stack and call
+destructors automatically. Austral, because of its emphasis on
+implementation simplicty, has <em>much</em> more verbose code around
+error handling.</p></li>
 </ol>
-<p>Austral takes the approach that a language should be <em>simple enough that it can be understood entirely by a single person reading the specification</em>. Consequently, a programmer should be able to read a brief set of linearity checker rules, and afterwards be able to write code without fighting the system, or failing to understand how or why some code compiles.</p>
-<p>In short: we sacrifice terseness and programmer ergonomics for simplicity. Simple to learn, simple to understand, simple to reason about.</p>
-<p>To do this, we choose linearity via kinds, because it provides the simplest way to implement a linear type system. The set of unrestricted types is called the “free universe” and is denoted <code>Free</code> (because <code>Unrestricted</code> takes too much typing) and the set of restricted or linear types is called the “linear universe” and is denoted <code>Linear</code>.</p>
-<p>Another feature that was considered and discarded is <a href="https://github.com/pikatchu/LinearML">LinearML</a>’s concept of <em>observer types</em>, a lightweight alternative to read-only references that has the benefit of not requiring regions, but has the drawback that they can’t be stored in data structures.</p>
+<p>Austral takes the approach that a language should be <em>simple
+enough that it can be understood entirely by a single person reading the
+specification</em>. Consequently, a programmer should be able to read a
+brief set of linearity checker rules, and afterwards be able to write
+code without fighting the system, or failing to understand how or why
+some code compiles.</p>
+<p>In short: we sacrifice terseness and programmer ergonomics for
+simplicity. Simple to learn, simple to understand, simple to reason
+about.</p>
+<p>To do this, we choose linearity via kinds, because it provides the
+simplest way to implement a linear type system. The set of unrestricted
+types is called the “free universe” and is denoted <code>Free</code>
+(because <code>Unrestricted</code> takes too much typing) and the set of
+restricted or linear types is called the “linear universe” and is
+denoted <code>Linear</code>.</p>
+<p>Another feature that was considered and discarded is <a
+href="https://github.com/pikatchu/LinearML">LinearML</a>’s concept of
+<em>observer types</em>, a lightweight alternative to read-only
+references that has the benefit of not requiring regions, but has the
+drawback that they can’t be stored in data structures.</p>
 <h3 id="rationale-linear-conclusion">Conclusion</h3>
-<p>In the next section, we explain the rationale for Austral’s approach to error handling, why linear types are incompatible with traditional exception handling, what affine types are, and how our preferred error handling scheme impacts the choice of linear types over affine types.</p>
-<p>Afterwards, we describe capability-based security, and how linear types allow us to implement capabilities.</p>
+<p>In the next section, we explain the rationale for Austral’s approach
+to error handling, why linear types are incompatible with traditional
+exception handling, what affine types are, and how our preferred error
+handling scheme impacts the choice of linear types over affine
+types.</p>
+<p>Afterwards, we describe capability-based security, and how linear
+types allow us to implement capabilities.</p>
 <h2 id="rationale-errors">Error Handling</h2>
-<p>On July 3, 1940, as part of Operation Catapult, Royal Air Force pilots bombed the ships of the French Navy stationed off Mers-el-Kébir to prevent them falling into the hands of the Third Reich.</p>
-<p>This is Austral’s approach to error handling: scuttle the ship without delay.</p>
-<p>In software terms: programs should crash at the slightest contract violation, because recovery efforts can become attack vectors. You must assume, when the program enters an invalid state, that there is an adversary in the system. For <em>failures</em> — as opposed to <em>errors</em> — you should use <code>Option</code> and <code>Result</code> types.</p>
-<p>This section describes the rationale for Austral’s approach to error handling. We begin by describing what an error is, then we survey different error handling strategies. Then we explain how those strategies impinge upon a linear type system.</p>
+<p>On July 3, 1940, as part of Operation Catapult, Royal Air Force
+pilots bombed the ships of the French Navy stationed off Mers-el-Kébir
+to prevent them falling into the hands of the Third Reich.</p>
+<p>This is Austral’s approach to error handling: scuttle the ship
+without delay.</p>
+<p>In software terms: programs should crash at the slightest contract
+violation, because recovery efforts can become attack vectors. You must
+assume, when the program enters an invalid state, that there is an
+adversary in the system. For <em>failures</em> — as opposed to
+<em>errors</em> — you should use <code>Option</code> and
+<code>Result</code> types.</p>
+<p>This section describes the rationale for Austral’s approach to error
+handling. We begin by describing what an error is, then we survey
+different error handling strategies. Then we explain how those
+strategies impinge upon a linear type system.</p>
 <h3 id="error-categories">Categorizing Errors</h3>
-<p>“Error” is a broad term. Following <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0709r4.pdf">Sutter</a> and the <a href="http://joeduffyblog.com/2016/02/07/the-error-model/">Midori error model</a>, we divide errors into the following categories:</p>
+<p>“Error” is a broad term. Following <a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0709r4.pdf">Sutter</a>
+and the <a
+href="http://joeduffyblog.com/2016/02/07/the-error-model/">Midori error
+model</a>, we divide errors into the following categories:</p>
 <ol type="1">
-<li><p><strong>Physical Failure:</strong> Pulling the power cord, destroying part of the hardware.</p></li>
-<li><p><strong>Abstract Machine Corruption:</strong> A stack overflow.</p></li>
-<li><p><strong>Contract Violations:</strong> Due to a mistake the code, the program enters an invalid state. This includes:</p>
+<li><p><strong>Physical Failure:</strong> Pulling the power cord,
+destroying part of the hardware.</p></li>
+<li><p><strong>Abstract Machine Corruption:</strong> A stack
+overflow.</p></li>
+<li><p><strong>Contract Violations:</strong> Due to a mistake the code,
+the program enters an invalid state. This includes:</p>
 <ol type="1">
-<li><p>An arithmetic operation leads to integer overflow or underflow (the contract here is that operands should be such that the operation does not overflow).</p></li>
-<li><p>Integer division by zero (the contract is the divisor should be non zero).</p></li>
-<li><p>Attempting to access an array with an index outside the array’s bounds (the contract is that the index should be within the length of the array).</p></li>
-<li><p>Any violation of a programmer-defined precondition, postcondition, assertion or invariant.</p></li>
+<li><p>An arithmetic operation leads to integer overflow or underflow
+(the contract here is that operands should be such that the operation
+does not overflow).</p></li>
+<li><p>Integer division by zero (the contract is the divisor should be
+non zero).</p></li>
+<li><p>Attempting to access an array with an index outside the array’s
+bounds (the contract is that the index should be within the length of
+the array).</p></li>
+<li><p>Any violation of a programmer-defined precondition,
+postcondition, assertion or invariant.</p></li>
 </ol>
-<p>These errors are bugs in the program. They are unpredictable, often happen very rarely, and can open the door to security vulnerabilities.</p></li>
-<li><p><strong>Memory Allocation Failure:</strong> <code>malloc</code> returns <code>null</code>, essentially. This gets its own category because allocation is pervasive, especially in higher-level code, and allocation failure is rarely modeled at the type level.</p></li>
-<li><p><strong>Failure Conditions</strong>. “File not found”, “connection failed”, “directory is not empty”, “timeout exceeded”.</p></li>
+<p>These errors are bugs in the program. They are unpredictable, often
+happen very rarely, and can open the door to security
+vulnerabilities.</p></li>
+<li><p><strong>Memory Allocation Failure:</strong> <code>malloc</code>
+returns <code>null</code>, essentially. This gets its own category
+because allocation is pervasive, especially in higher-level code, and
+allocation failure is rarely modeled at the type level.</p></li>
+<li><p><strong>Failure Conditions</strong>. “File not found”,
+“connection failed”, “directory is not empty”, “timeout
+exceeded”.</p></li>
 </ol>
 <p>We can pare down what we have to care about:</p>
 <ol type="1">
-<li><p><strong>Physical Failure:</strong> Nothing can be done. Although it is possible to write software that persists data in a way that survives e.g. power failure. Databases are often implemented in this way.</p></li>
-<li><p><strong>Abstract Machine Corruption</strong>. The program should terminate. At this point the program is in a highly problematic state and any attempt at recovery is likely counterproductive and possibly enables security vulnerabilities.</p></li>
-<li><p><strong>Memory Allocation Failure:</strong> Programs written in a functional style often rely on memory allocation at arbitrary points in the program execution. Allocation failure in a deeply nested function thus presents a problem from an error-handling perspective: if we’re using values to represent failures, then every function that allocates has to return an <code>Optional</code> type or equivalent, and this propagates up through every client of that function.</p>
-<p>Nevertheless, returning an <code>Optional</code> type (or equivalent) on memory allocation is sufficient. It places a minor burden on the programmer, who has to explicitly handle and propagate these failures, but this burden can be eased by refactoring the program so that most allocations happen in the same area in time and space.</p>
-<p>This type of refactoring can improve performance, as putting allocations together will make it clear when there is an opportunity to replace <span class="math inline">\(n\)</span> allocations of an object of size <span class="math inline">\(k\)</span> bytes with a single allocation of an array of <span class="math inline">\(n \times k\)</span> bytes.</p>
-<p>A common misconception is that checking for allocation failure is pointless, since a program might be terminated by the OS if memory is exhausted, or because platforms that implement memory overcommit (such as Linux) will always return a pointer as though allocation had succeeded, and crash when writing to that pointer. This is a misconception for the following reasons:</p>
+<li><p><strong>Physical Failure:</strong> Nothing can be done. Although
+it is possible to write software that persists data in a way that
+survives e.g. power failure. Databases are often implemented in this
+way.</p></li>
+<li><p><strong>Abstract Machine Corruption</strong>. The program should
+terminate. At this point the program is in a highly problematic state
+and any attempt at recovery is likely counterproductive and possibly
+enables security vulnerabilities.</p></li>
+<li><p><strong>Memory Allocation Failure:</strong> Programs written in a
+functional style often rely on memory allocation at arbitrary points in
+the program execution. Allocation failure in a deeply nested function
+thus presents a problem from an error-handling perspective: if we’re
+using values to represent failures, then every function that allocates
+has to return an <code>Optional</code> type or equivalent, and this
+propagates up through every client of that function.</p>
+<p>Nevertheless, returning an <code>Optional</code> type (or equivalent)
+on memory allocation is sufficient. It places a minor burden on the
+programmer, who has to explicitly handle and propagate these failures,
+but this burden can be eased by refactoring the program so that most
+allocations happen in the same area in time and space.</p>
+<p>This type of refactoring can improve performance, as putting
+allocations together will make it clear when there is an opportunity to
+replace <span class="math inline">\(n\)</span> allocations of an object
+of size <span class="math inline">\(k\)</span> bytes with a single
+allocation of an array of <span class="math inline">\(n \times
+k\)</span> bytes.</p>
+<p>A common misconception is that checking for allocation failure is
+pointless, since a program might be terminated by the OS if memory is
+exhausted, or because platforms that implement memory overcommit (such
+as Linux) will always return a pointer as though allocation had
+succeeded, and crash when writing to that pointer. This is a
+misconception for the following reasons:</p>
 <ol type="1">
 <li><p>Memory overcommit on Linux can be turned off.</p></li>
 <li><p>Linux is not the only platform.</p></li>
-<li><p>Memory exhaustion is <em>not</em> the only situation where allocation might fail: if memory is sufficiently fragmented that a chunk of the requested size is not available, allocation will fail.</p></li>
+<li><p>Memory exhaustion is <em>not</em> the only situation where
+allocation might fail: if memory is sufficiently fragmented that a chunk
+of the requested size is not available, allocation will fail.</p></li>
 </ol></li>
-<li><p><strong>Failure Conditions</strong>. These errors are recoverable, in the sense that we want to catch them and do something about them, rather than crash. Often this involves prompting the user for corrected information, or otherwise informing the user of failure, e.g. if trying to open a file on a user-provided path, or trying to connect to a server with a user-provided host and port.</p>
-<p>Consequently, these conditions should be represented as values, and error handling should be done using standard control flow.</p>
-<p>Values that represent failure should not be confused with “error codes” in languages like C. “Error codes or exceptions” is a false dichotomy. Firstly, strongly-typed result values are better than brittle integer error codes. Secondly, an appropriate type system lets us have e.g. <code>Optional</code> or <code>Result</code> types to better represent the result of fallible computations. Thirdly, a linear type system can force the programmer to check result codes, so the argument that error codes are bad because programmers might forget to check them is obviated.</p></li>
+<li><p><strong>Failure Conditions</strong>. These errors are
+recoverable, in the sense that we want to catch them and do something
+about them, rather than crash. Often this involves prompting the user
+for corrected information, or otherwise informing the user of failure,
+e.g. if trying to open a file on a user-provided path, or trying to
+connect to a server with a user-provided host and port.</p>
+<p>Consequently, these conditions should be represented as values, and
+error handling should be done using standard control flow.</p>
+<p>Values that represent failure should not be confused with “error
+codes” in languages like C. “Error codes or exceptions” is a false
+dichotomy. Firstly, strongly-typed result values are better than brittle
+integer error codes. Secondly, an appropriate type system lets us have
+e.g. <code>Optional</code> or <code>Result</code> types to better
+represent the result of fallible computations. Thirdly, a linear type
+system can force the programmer to check result codes, so the argument
+that error codes are bad because programmers might forget to check them
+is obviated.</p></li>
 </ol>
-<p>That takes care of four of five categories. There’s one left: what do we do about contract violations? How we choose to handle this is a critical question in the design of any programming language.</p>
+<p>That takes care of four of five categories. There’s one left: what do
+we do about contract violations? How we choose to handle this is a
+critical question in the design of any programming language.</p>
 <h3 id="error-contracts">Error Handling for Contract Violations</h3>
-<p>There are essentially three approaches, from most to least brutal:</p>
+<p>There are essentially three approaches, from most to least
+brutal:</p>
 <ol type="1">
-<li><p><strong>Terminate Program:</strong> When a contract violation is detected, terminate the entire program. No cleanup code is executed. Henceforth “TPOE” for “terminate program on error”.</p></li>
-<li><p><strong>Terminate Thread:</strong> When a contract violation is detected, terminate the current thread or task. No cleanup code is executed, but the parent thread will observe the failure, and can decide what to do about it. Henceforth “TTOE” for “terminate thread/task on error”.</p></li>
-<li><p><strong>Traditional Exception Handling:</strong> Raise an exception/panic/abort (pick your preferred terminology), unwind the stack while calling destructors. This is the approach offered by C++ and Rust, and it integrates with RAII. Henceforth “REOE” for “raise exception on error”.</p></li>
+<li><p><strong>Terminate Program:</strong> When a contract violation is
+detected, terminate the entire program. No cleanup code is executed.
+Henceforth “TPOE” for “terminate program on error”.</p></li>
+<li><p><strong>Terminate Thread:</strong> When a contract violation is
+detected, terminate the current thread or task. No cleanup code is
+executed, but the parent thread will observe the failure, and can decide
+what to do about it. Henceforth “TTOE” for “terminate thread/task on
+error”.</p></li>
+<li><p><strong>Traditional Exception Handling:</strong> Raise an
+exception/panic/abort (pick your preferred terminology), unwind the
+stack while calling destructors. This is the approach offered by C++ and
+Rust, and it integrates with RAII. Henceforth “REOE” for “raise
+exception on error”.</p></li>
 </ol>
 <h4 id="terminate-program">Terminate Program</h4>
-<p>The benefit of this approach is simplicity and security: from the perspective of security vulnerabilities, terminating a program outright is the best thing to do,</p>
-<p>If the program is the target of an attacker, cleanup or error handling code might inadvertently allow an attacker to gain access to the program. Terminating the program without executing any cleanup code at all will prevent this.</p>
-<p>The key benefit here besides security is simplicty. There is nothing simpler than calling <code>_exit(-1)</code>. The language is simpler and easier to understand. The language also becomes simpler to implement. The runtime is simpler. Code written in the language is simpler to understand and reason about: there are no implicit function calls, no surprise control flow, no complicated unwinding schemes.</p>
+<p>The benefit of this approach is simplicity and security: from the
+perspective of security vulnerabilities, terminating a program outright
+is the best thing to do,</p>
+<p>If the program is the target of an attacker, cleanup or error
+handling code might inadvertently allow an attacker to gain access to
+the program. Terminating the program without executing any cleanup code
+at all will prevent this.</p>
+<p>The key benefit here besides security is simplicty. There is nothing
+simpler than calling <code>_exit(-1)</code>. The language is simpler and
+easier to understand. The language also becomes simpler to implement.
+The runtime is simpler. Code written in the language is simpler to
+understand and reason about: there are no implicit function calls, no
+surprise control flow, no complicated unwinding schemes.</p>
 <p>There are, however, a number of problems:</p>
 <ol type="1">
-<li><p><strong>Resource Leaks:</strong> Depending on the program and the operating system, doing this might leak resources.</p>
-<p>If the program only allocates memory and acquires file and/or socket handles, then the operating system will likely be able to garbage-collect all of this on program termination. If the program uses more exotic resources, such as locks that survive program termination, then the system as a whole might enter an unusable state where the program cannot be restarted (since the relevant objects are still locked), and human intervention is needed to delete those surviving resources.</p>
-<p>For example, consider a build. The program might use a linear type to represent the lifecycle of the directory that stores build output. A <code>create</code> function creates the directory if it does not already exist, a corresponding <code>destroy</code> function deletes the directory and its contents.</p>
-<p>If the program is terminated before the <code>destroy</code> function is called, running the program again will fail in the call to <code>create</code> because the directory already exists.</p>
-<p>Additionally, in embedded systems without an operating system, allocated resources that are not cleaned up by the program will not be reclaimed by anything.</p></li>
-<li><p><strong>Testing:</strong> In a testing framework, we often want to test that a function will not fail on certain inputs, or that it will definitely fail on certain others. For example, we may want to test that a function correctly aborts on values that don’t satisfy some precondition.</p>
-<p><a href="https://en.wikipedia.org/wiki/JUnit">JUnit</a>, for example, provides <a href="https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertThrows-java.lang.Class-org.junit.jupiter.api.function.Executable-"><code>assertThrows</code></a> for this purpose.</p>
-<p>If contract violations terminate the program, then the only way to write an <code>assertAborts</code> function is to fork the process, run the function in the child process, and have the parent process observe whether or not it crashes. This is expensive. And if we don’t implement this, a contract violation will crash the entire unit testing process.</p>
-<p>This is a problem because, while we are implicitly “testing” for contract violations whenever a function is called, it is still good to have explicit unit tests that we can point to in order to prove that a function does indeed reject certain kinds of values.</p></li>
-<li><p><strong>Exporting Code:</strong> When exporting code through the FFI, terminating the program on contract violations is less than polite.</p>
-<p>If we write a library and export its functionality through the FFI so it is accessible from other languages, terminating the process from that library will crash everything else in the address space. All the code that uses our library can potentially crash on certain obscure error conditions, a situation that would be extremely difficult to debug due to its crossing language boundaries.</p>
-<p>The option of forking the process, in this context, is prohibitively expensive.</p></li>
+<li><p><strong>Resource Leaks:</strong> Depending on the program and the
+operating system, doing this might leak resources.</p>
+<p>If the program only allocates memory and acquires file and/or socket
+handles, then the operating system will likely be able to
+garbage-collect all of this on program termination. If the program uses
+more exotic resources, such as locks that survive program termination,
+then the system as a whole might enter an unusable state where the
+program cannot be restarted (since the relevant objects are still
+locked), and human intervention is needed to delete those surviving
+resources.</p>
+<p>For example, consider a build. The program might use a linear type to
+represent the lifecycle of the directory that stores build output. A
+<code>create</code> function creates the directory if it does not
+already exist, a corresponding <code>destroy</code> function deletes the
+directory and its contents.</p>
+<p>If the program is terminated before the <code>destroy</code> function
+is called, running the program again will fail in the call to
+<code>create</code> because the directory already exists.</p>
+<p>Additionally, in embedded systems without an operating system,
+allocated resources that are not cleaned up by the program will not be
+reclaimed by anything.</p></li>
+<li><p><strong>Testing:</strong> In a testing framework, we often want
+to test that a function will not fail on certain inputs, or that it will
+definitely fail on certain others. For example, we may want to test that
+a function correctly aborts on values that don’t satisfy some
+precondition.</p>
+<p><a href="https://en.wikipedia.org/wiki/JUnit">JUnit</a>, for example,
+provides <a
+href="https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertThrows-java.lang.Class-org.junit.jupiter.api.function.Executable-"><code>assertThrows</code></a>
+for this purpose.</p>
+<p>If contract violations terminate the program, then the only way to
+write an <code>assertAborts</code> function is to fork the process, run
+the function in the child process, and have the parent process observe
+whether or not it crashes. This is expensive. And if we don’t implement
+this, a contract violation will crash the entire unit testing
+process.</p>
+<p>This is a problem because, while we are implicitly “testing” for
+contract violations whenever a function is called, it is still good to
+have explicit unit tests that we can point to in order to prove that a
+function does indeed reject certain kinds of values.</p></li>
+<li><p><strong>Exporting Code:</strong> When exporting code through the
+FFI, terminating the program on contract violations is less than
+polite.</p>
+<p>If we write a library and export its functionality through the FFI so
+it is accessible from other languages, terminating the process from that
+library will crash everything else in the address space. All the code
+that uses our library can potentially crash on certain obscure error
+conditions, a situation that would be extremely difficult to debug due
+to its crossing language boundaries.</p>
+<p>The option of forking the process, in this context, is prohibitively
+expensive.</p></li>
 </ol>
 <h4 id="terminate-thread">Terminate Thread on Error</h4>
-<p>Terminating the thread where the contract violation happened, rather than the entire process, gives us a bit more recoverability and error reporting ability, at the cost of safety and resource leaks.</p>
-<p>The benefit is that calling a potentially-failing function safely “only” requires spawning a new thread. While expensive (and not feasible in a function that might be called thousands of times a second) this is significantly cheaper than forking the process.</p>
-<p>A unit testing library could plausibly do this to implement assertions that a program does or does not violate any conditions. Condition failures could then be reported within the unit testing framework as just another failing test, without crashing the entire process or requiring expensive forking of the process.</p>
-<p>If we split programs into communicating threads, the failure of one thread could be detected by its parent, and reported to the user before the program is terminated.</p>
-<p>This is important: <em>the program should still be terminated</em>. Terminating the thread, rather than the entire program, is inteded to allow more user-friendly and complete reporting of failures, not as a general purpose error recovery mechanism.</p>
-<p>For example, in the context of a webserver, we would <em>not</em> want to restart failed server threads. Since cleanup code is not executed on thread termination, a long running process which restarts failing threads will eventually run out of memory or file handles or other resources.</p>
-<p>An attacker that knows the server does this could execute a denial of service attack by forcing a previously undetected contract violation.</p>
+<p>Terminating the thread where the contract violation happened, rather
+than the entire process, gives us a bit more recoverability and error
+reporting ability, at the cost of safety and resource leaks.</p>
+<p>The benefit is that calling a potentially-failing function safely
+“only” requires spawning a new thread. While expensive (and not feasible
+in a function that might be called thousands of times a second) this is
+significantly cheaper than forking the process.</p>
+<p>A unit testing library could plausibly do this to implement
+assertions that a program does or does not violate any conditions.
+Condition failures could then be reported within the unit testing
+framework as just another failing test, without crashing the entire
+process or requiring expensive forking of the process.</p>
+<p>If we split programs into communicating threads, the failure of one
+thread could be detected by its parent, and reported to the user before
+the program is terminated.</p>
+<p>This is important: <em>the program should still be terminated</em>.
+Terminating the thread, rather than the entire program, is inteded to
+allow more user-friendly and complete reporting of failures, not as a
+general purpose error recovery mechanism.</p>
+<p>For example, in the context of a webserver, we would <em>not</em>
+want to restart failed server threads. Since cleanup code is not
+executed on thread termination, a long running process which restarts
+failing threads will eventually run out of memory or file handles or
+other resources.</p>
+<p>An attacker that knows the server does this could execute a denial of
+service attack by forcing a previously undetected contract
+violation.</p>
 <h4 id="raise-exception">Raise Exception on Error</h4>
-<p>This is traditional exception handling with exception values, stack unwinding, and destructors. C++ calls this throwing an exception. Rust and Go call it panicking. The only technical difference between C++ exception handling and Go/Rust panics is that C++ exceptions can be arbitrarily sized objects (and consequently throwing requires a memory allocation) while in Go and Rust panics can at most carry an error message. Ada works similarly: an exception is a type tag plus an error message string.</p>
-<p>When a contract violation is detected, an exception is raised and stack unwinding begins. The stack unwinding process calls destructors. If an appropriate handler is reached, control transfers to that handler after stack unwinding. If no handler is reached, the thread is terminated, and the parent thread receives the exception object.</p>
-<p>Implementing exception handling mainly requires having a way to associate types with destructors.</p>
-<p>When a value goes out of scope or its scope is entire wiped by stack unwinding, we need to destroy that value. This is done by <em>destructors</em>: functions <code>A -&gt; Unit</code> that consume the value, deallocate it, close file handles etc. and return nothing.</p>
-<p>Type classes are enough to implement destructors. We’d have a typeclass:</p>
+<p>This is traditional exception handling with exception values, stack
+unwinding, and destructors. C++ calls this throwing an exception. Rust
+and Go call it panicking. The only technical difference between C++
+exception handling and Go/Rust panics is that C++ exceptions can be
+arbitrarily sized objects (and consequently throwing requires a memory
+allocation) while in Go and Rust panics can at most carry an error
+message. Ada works similarly: an exception is a type tag plus an error
+message string.</p>
+<p>When a contract violation is detected, an exception is raised and
+stack unwinding begins. The stack unwinding process calls destructors.
+If an appropriate handler is reached, control transfers to that handler
+after stack unwinding. If no handler is reached, the thread is
+terminated, and the parent thread receives the exception object.</p>
+<p>Implementing exception handling mainly requires having a way to
+associate types with destructors.</p>
+<p>When a value goes out of scope or its scope is entire wiped by stack
+unwinding, we need to destroy that value. This is done by
+<em>destructors</em>: functions <code>A -&gt; Unit</code> that consume
+the value, deallocate it, close file handles etc. and return
+nothing.</p>
+<p>Type classes are enough to implement destructors. We’d have a
+typeclass:</p>
 <pre><code>typeclass Destructable(T) is
     method destroy(value: T): Unit;
 end;</code></pre>
-<p>And implement instances for types that need cleanup. Then the compiler inserts destructor calls at the end of scope and in stack unwinding code.</p>
+<p>And implement instances for types that need cleanup. Then the
+compiler inserts destructor calls at the end of scope and in stack
+unwinding code.</p>
 <p>The benefits of this approach are:</p>
 <ol type="1">
-<li><p><strong>Resource Safety:</strong> Contract violations will unwind the stack and cause destructors to be called, which allows us to safely deallocate resources (with some caveats, see below).</p>
-<p>We can write servers where specific worker threads can occasionally tip over, but the file/socket handles are safely closed, and the entire server does not crash.</p>
-<p>When the parent thread of a failing thread receives an exception, it can decide whether to restart the thread, or simply rethrow the exception. In the latter case, its own stack would be unwound and its own resources deallocated. Transitively, an exception that is not caught anywhere and reaches the top of the stack will terminate the program only after all resources have been safely deallocated.</p></li>
-<li><p><strong>Testing:</strong> Contract violations can be caught during test execution and reported appropriately, without needing to spawn a new thread or a new process.</p></li>
-<li><p><strong>Exporting Code:</strong> Code that is built to be exported through the C ABI can catch all exceptions, convert them to values, and return appropriate error values through the FFI boundary. Rust libraries that export Rust code through the FFI use <a href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a> to do this.</p></li>
+<li><p><strong>Resource Safety:</strong> Contract violations will unwind
+the stack and cause destructors to be called, which allows us to safely
+deallocate resources (with some caveats, see below).</p>
+<p>We can write servers where specific worker threads can occasionally
+tip over, but the file/socket handles are safely closed, and the entire
+server does not crash.</p>
+<p>When the parent thread of a failing thread receives an exception, it
+can decide whether to restart the thread, or simply rethrow the
+exception. In the latter case, its own stack would be unwound and its
+own resources deallocated. Transitively, an exception that is not caught
+anywhere and reaches the top of the stack will terminate the program
+only after all resources have been safely deallocated.</p></li>
+<li><p><strong>Testing:</strong> Contract violations can be caught
+during test execution and reported appropriately, without needing to
+spawn a new thread or a new process.</p></li>
+<li><p><strong>Exporting Code:</strong> Code that is built to be
+exported through the C ABI can catch all exceptions, convert them to
+values, and return appropriate error values through the FFI boundary.
+Rust libraries that export Rust code through the FFI use <a
+href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a>
+to do this.</p></li>
 </ol>
 <p>There are, however, significant downsides to exception handling:</p>
 <ol type="1">
-<li><p><strong>Complexity:</strong> Exceptions are among the most complex language features. This complexity is reflected in the semantics, which makes the language harder to describe, harder to formalize, harder to learn, and harder to implement. Consequently the code is harder to reason about, since exceptions introduce surprise control flow at literally every program point.</p></li>
-<li><p><strong>Pessimization:</strong> When exceptions are part of the language semantics, and any function can throw, many compiler optimizations become unavailable.</p></li>
-<li><p><strong>Code Size:</strong> Exception handling support, even so called “zero cost exception handling”, requires sizeable cleanup code to be written. This has a cost in the size of the resulting binaries. Larger binaries can result in a severe performance penalty if the code does not fit in the instruction cache.</p></li>
-<li><p><strong>Hidden Function Calls:</strong> Calls to destructors are inserted by the compiler, both on normal exit from a scope and on cleanup. This makes destructors an invisible cost.</p>
-<p>This is worsened by the fact that destructors are often recursive: destroying a record requires destroying every field, destroying an array requires destroying every element.</p></li>
-<li><p><strong>No Checking:</strong> exceptions bypass the type system. Solutions like checked exceptions in Java exist, but are unused, because they provide little benefit in exchange for onerous restrictions. The introduction of checked exceptions is also no small matter: it affects the specification of function signatures and generic functions, since you need a way to do “throwingness polymorphism” (really, effect polymorphism). Any function that takes a function as an argument has to annotate not just the function’s type signature but its permitted exception signature.</p></li>
-<li><p><strong>Pervasive Failure:</strong> If contract violations can throw, then essentially every function can throw, because every function has to perform arithmetic, either directly or transitively. So there is little point to a <code>throws</code> annotation like what Herb Sutter suggests or Swift provides, let alone full blown checked exceptions, since every function would have to be annotated with <code>throws (Overflow_Error)</code>.</p></li>
-<li><p><strong>Double Throw Problem:</strong> What do we do when the destructor throws? This problem affects every language that has RAII.</p>
-<p>In C++ and Rust, throwing in the destructor causes the program to abort. This an unsatisfactory solution: we’re paying the semantic and runtime cost of exceptions, stack unwinding, and destructors, but a bug in the destructor invalidates all of this. If we’re throwing on a contract violation, it is because we expect the code has bugs in it and we want to recover gracefully from those bugs. Therefore, it is unreasonable to expect that destructors will be bug-free.</p>
-<p>Ada works differently in that raising an exception in a finalizer throws an entirely new exception (discarding the original one).</p>
-<p>Double throw is not necessarily a pathological edge case either: the <code>fclose</code> function from the C standard library returns a result code. What should the destructor of a file object do when <code>fclose</code> returns an error code?</p>
-<p>In Rust, according to the documentation of the <code>std::fs::File</code> object: “Files are automatically closed when they go out of scope. Errors detected on closing are ignored by the implementation of Drop. Use the method <code>sync_all</code> if these errors must be manually handled.”</p>
-<p>A solution would be to store a flag in the file object that records the state of the file handle: either <code>closed</code> or <code>open</code>. Then, we can have a function <code>close : File -&gt; ReturnCode</code> that calls <code>fclose</code>, sets the flag to <code>closed</code>, and returns the return code for the client to handle. The destructor would then check that flag: if the flag is <code>open</code>, it calls <code>fclose</code>, ignoring the return code (or aborting if <code>fclose</code> reports an error), and if the flag is <code>closed</code>, the destructor does nothing.</p>
+<li><p><strong>Complexity:</strong> Exceptions are among the most
+complex language features. This complexity is reflected in the
+semantics, which makes the language harder to describe, harder to
+formalize, harder to learn, and harder to implement. Consequently the
+code is harder to reason about, since exceptions introduce surprise
+control flow at literally every program point.</p></li>
+<li><p><strong>Pessimization:</strong> When exceptions are part of the
+language semantics, and any function can throw, many compiler
+optimizations become unavailable.</p></li>
+<li><p><strong>Code Size:</strong> Exception handling support, even so
+called “zero cost exception handling”, requires sizeable cleanup code to
+be written. This has a cost in the size of the resulting binaries.
+Larger binaries can result in a severe performance penalty if the code
+does not fit in the instruction cache.</p></li>
+<li><p><strong>Hidden Function Calls:</strong> Calls to destructors are
+inserted by the compiler, both on normal exit from a scope and on
+cleanup. This makes destructors an invisible cost.</p>
+<p>This is worsened by the fact that destructors are often recursive:
+destroying a record requires destroying every field, destroying an array
+requires destroying every element.</p></li>
+<li><p><strong>No Checking:</strong> exceptions bypass the type system.
+Solutions like checked exceptions in Java exist, but are unused, because
+they provide little benefit in exchange for onerous restrictions. The
+introduction of checked exceptions is also no small matter: it affects
+the specification of function signatures and generic functions, since
+you need a way to do “throwingness polymorphism” (really, effect
+polymorphism). Any function that takes a function as an argument has to
+annotate not just the function’s type signature but its permitted
+exception signature.</p></li>
+<li><p><strong>Pervasive Failure:</strong> If contract violations can
+throw, then essentially every function can throw, because every function
+has to perform arithmetic, either directly or transitively. So there is
+little point to a <code>throws</code> annotation like what Herb Sutter
+suggests or Swift provides, let alone full blown checked exceptions,
+since every function would have to be annotated with
+<code>throws (Overflow_Error)</code>.</p></li>
+<li><p><strong>Double Throw Problem:</strong> What do we do when the
+destructor throws? This problem affects every language that has
+RAII.</p>
+<p>In C++ and Rust, throwing in the destructor causes the program to
+abort. This an unsatisfactory solution: we’re paying the semantic and
+runtime cost of exceptions, stack unwinding, and destructors, but a bug
+in the destructor invalidates all of this. If we’re throwing on a
+contract violation, it is because we expect the code has bugs in it and
+we want to recover gracefully from those bugs. Therefore, it is
+unreasonable to expect that destructors will be bug-free.</p>
+<p>Ada works differently in that raising an exception in a finalizer
+throws an entirely new exception (discarding the original one).</p>
+<p>Double throw is not necessarily a pathological edge case either: the
+<code>fclose</code> function from the C standard library returns a
+result code. What should the destructor of a file object do when
+<code>fclose</code> returns an error code?</p>
+<p>In Rust, according to the documentation of the
+<code>std::fs::File</code> object: “Files are automatically closed when
+they go out of scope. Errors detected on closing are ignored by the
+implementation of Drop. Use the method <code>sync_all</code> if these
+errors must be manually handled.”</p>
+<p>A solution would be to store a flag in the file object that records
+the state of the file handle: either <code>closed</code> or
+<code>open</code>. Then, we can have a function
+<code>close : File -&gt; ReturnCode</code> that calls
+<code>fclose</code>, sets the flag to <code>closed</code>, and returns
+the return code for the client to handle. The destructor would then
+check that flag: if the flag is <code>open</code>, it calls
+<code>fclose</code>, ignoring the return code (or aborting if
+<code>fclose</code> reports an error), and if the flag is
+<code>closed</code>, the destructor does nothing.</p>
 <p>But this is a non-solution.</p>
 <ol type="1">
-<li><p>With affine types and RAII, we cannot force the programmer to call the <code>close</code> function. If a file object is silently discarded, the compiler will insert a call to the destructor, which as we’ve seen makes fewer safety guarantees. So we have a type system to manage resources, but it doesn’t force us to handle them properly.</p></li>
-<li><p>We’re paying a cost, in space and time, in having a flag that records the file handle state and which needs to be set and checked at runtime. The whole point of resource management type systems is <em>the flag exists at compile time</em>. Otherwise we might as well have reference counting.</p></li>
+<li><p>With affine types and RAII, we cannot force the programmer to
+call the <code>close</code> function. If a file object is silently
+discarded, the compiler will insert a call to the destructor, which as
+we’ve seen makes fewer safety guarantees. So we have a type system to
+manage resources, but it doesn’t force us to handle them
+properly.</p></li>
+<li><p>We’re paying a cost, in space and time, in having a flag that
+records the file handle state and which needs to be set and checked at
+runtime. The whole point of resource management type systems is <em>the
+flag exists at compile time</em>. Otherwise we might as well have
+reference counting.</p></li>
 </ol></li>
-<li><p><strong>Compile Time:</strong> Compilers anecdotally spend a lot of time compiling landingpads.</p></li>
-<li><p><strong>Non-Determinism:</strong> Time and space cost of exceptions is completely unknown and not amenable to static analysis.</p></li>
-<li><p><strong>Platform-Specific Runtime Support:</strong> Exceptions need support from the runtime, usually involving the generation of DWARF metadata and platform specific assembly. This is the case with Itanium ABI “zero-cost exceptions” for C++, which LLVM implements.</p></li>
-<li><p><strong>Corruption:</strong> Unwinding deallocates resources, but this is not all we need. Data structures can be left in a broken, inconsistent state, the use of which would trigger further contract violations when their invariants are violated.</p>
-<p>This can be mitigated somewhat by not allowing the catching of exceptions except at thread boundaries, beyond which the internal broken data structures cannot be observed. Thus threads act as a kind of censor of broken data. Providing the strong exception guarantee requires either transactional memory semantics (and their implied runtime cost in both time, space, and implementation complexity) or carefully writing every data structure to handle unwinding gracefully.</p>
-<p>However, making it impossible to catch errors not at thread boundaries makes it impossible to safely export code through the C FFI without spawning a new thread. Rust started out with this restriction, whereby panics can only be caught by parent threads of a failing thread. The restriction was removed with the implementation of <a href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a>.</p>
-<p>Furthermore, carefully writing every data structure to implement strong exception safety is pointless when a compiler toggle can disable exception handling. Doubly so when writing a library, since control of whether or not to use exceptions falls on the client of that library (see below: <strong>Libraries Cannot Rely on Destructors</strong>).</p></li>
-<li><p><strong>Misuse of Exceptions:</strong> If catching an exception is possible, people will use it to implement a general <code>try/catch</code> mechanism, no matter how discouraged that is.</p>
-<p>For example, Rust’s <a href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a> is used in web servers. For example, in the <a href="https://docs.rs/">docs.rs</a> project, see <a href="https://news.ycombinator.com/item?id=22940836">here</a> and <a href="https://news.ycombinator.com/item?id=22938712">here</a>.</p></li>
-<li><p><strong>Minimum Common Denominator:</strong> Destructors are a minimum common denominator interface: a destructor is a function that takes an object and returns nothing, <code>A -&gt; ()</code>.</p>
-<p>Destructors force all resource-closing operations to conform to this interface, even if they can’t. The prototypical example has already been mentioned: <code>fclose</code> can return failure. How do languages with destructors deal with this?</p>
-<p>Again, in C++, closing a file object will explicitly forget that error, since throwing an exception would cause the program to abort. You are supposed to close the file manually, and protect that close function call from unwinding.</p>
-<p>Again, in Rust, closing a file will also ignore errors, because Rust works like C++ in that throwing from a destructor will abort the program. You can call <code>sync_all</code> before the destructor runs to ensure the buffer is flushed to disk. But, again: the compiler will not force you to call <code>sync_all</code> or to manually close the file.</p>
-<p>More generally, affine type systems <em>cannot</em> force the programmer to do anything: resources that are silently discarded will be destroyed by the compiler inserting a call to the destructor. Rust gets around this by implementing a <code>cfg(must_use)</code> annotation on functions, which essentially tells the compiler to force programmers to use the result code of that function.</p></li>
-<li><p><strong>Libraries Cannot Rely on Destructors:</strong> In C++, compilers often provide non-standard functionality to turn off exception handling. In this mode, <code>throw</code> is an abort and the body of a <code>catch</code> statement is dead code. Rust works similarly: a panic can cause stack unwinding (and concurrent destruction of stack objects) or a program abort, and this is configurable in the compiler. Unlike C++, this option is explicitly welcome in Rust.</p>
-<p>In both languages, the decision of whether or not to use exception handling takes place at the root of the dependency tree: at the application. This makes sense: the alternative is a model whereby a library that relies on unwinding will pass this requirement to other packages that depend on it, “infecting” dependents transitively up to the final application.</p>
-<p>For this reason, libraries written in either language cannot rely on unwinding for exception safety.</p>
-<p>It is not uncommon, however, for libraries to effectively rely on unwinding to occur in order to properly free resources. For example, the documentation for the <a href="https://docs.rs/easycurses/latest/easycurses/"><code>easycurses</code></a> library says:</p>
+<li><p><strong>Compile Time:</strong> Compilers anecdotally spend a lot
+of time compiling landingpads.</p></li>
+<li><p><strong>Non-Determinism:</strong> Time and space cost of
+exceptions is completely unknown and not amenable to static
+analysis.</p></li>
+<li><p><strong>Platform-Specific Runtime Support:</strong> Exceptions
+need support from the runtime, usually involving the generation of DWARF
+metadata and platform specific assembly. This is the case with Itanium
+ABI “zero-cost exceptions” for C++, which LLVM implements.</p></li>
+<li><p><strong>Corruption:</strong> Unwinding deallocates resources, but
+this is not all we need. Data structures can be left in a broken,
+inconsistent state, the use of which would trigger further contract
+violations when their invariants are violated.</p>
+<p>This can be mitigated somewhat by not allowing the catching of
+exceptions except at thread boundaries, beyond which the internal broken
+data structures cannot be observed. Thus threads act as a kind of censor
+of broken data. Providing the strong exception guarantee requires either
+transactional memory semantics (and their implied runtime cost in both
+time, space, and implementation complexity) or carefully writing every
+data structure to handle unwinding gracefully.</p>
+<p>However, making it impossible to catch errors not at thread
+boundaries makes it impossible to safely export code through the C FFI
+without spawning a new thread. Rust started out with this restriction,
+whereby panics can only be caught by parent threads of a failing thread.
+The restriction was removed with the implementation of <a
+href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a>.</p>
+<p>Furthermore, carefully writing every data structure to implement
+strong exception safety is pointless when a compiler toggle can disable
+exception handling. Doubly so when writing a library, since control of
+whether or not to use exceptions falls on the client of that library
+(see below: <strong>Libraries Cannot Rely on
+Destructors</strong>).</p></li>
+<li><p><strong>Misuse of Exceptions:</strong> If catching an exception
+is possible, people will use it to implement a general
+<code>try/catch</code> mechanism, no matter how discouraged that is.</p>
+<p>For example, Rust’s <a
+href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a>
+is used in web servers. For example, in the <a
+href="https://docs.rs/">docs.rs</a> project, see <a
+href="https://news.ycombinator.com/item?id=22940836">here</a> and <a
+href="https://news.ycombinator.com/item?id=22938712">here</a>.</p></li>
+<li><p><strong>Minimum Common Denominator:</strong> Destructors are a
+minimum common denominator interface: a destructor is a function that
+takes an object and returns nothing, <code>A -&gt; ()</code>.</p>
+<p>Destructors force all resource-closing operations to conform to this
+interface, even if they can’t. The prototypical example has already been
+mentioned: <code>fclose</code> can return failure. How do languages with
+destructors deal with this?</p>
+<p>Again, in C++, closing a file object will explicitly forget that
+error, since throwing an exception would cause the program to abort. You
+are supposed to close the file manually, and protect that close function
+call from unwinding.</p>
+<p>Again, in Rust, closing a file will also ignore errors, because Rust
+works like C++ in that throwing from a destructor will abort the
+program. You can call <code>sync_all</code> before the destructor runs
+to ensure the buffer is flushed to disk. But, again: the compiler will
+not force you to call <code>sync_all</code> or to manually close the
+file.</p>
+<p>More generally, affine type systems <em>cannot</em> force the
+programmer to do anything: resources that are silently discarded will be
+destroyed by the compiler inserting a call to the destructor. Rust gets
+around this by implementing a <code>cfg(must_use)</code> annotation on
+functions, which essentially tells the compiler to force programmers to
+use the result code of that function.</p></li>
+<li><p><strong>Libraries Cannot Rely on Destructors:</strong> In C++,
+compilers often provide non-standard functionality to turn off exception
+handling. In this mode, <code>throw</code> is an abort and the body of a
+<code>catch</code> statement is dead code. Rust works similarly: a panic
+can cause stack unwinding (and concurrent destruction of stack objects)
+or a program abort, and this is configurable in the compiler. Unlike
+C++, this option is explicitly welcome in Rust.</p>
+<p>In both languages, the decision of whether or not to use exception
+handling takes place at the root of the dependency tree: at the
+application. This makes sense: the alternative is a model whereby a
+library that relies on unwinding will pass this requirement to other
+packages that depend on it, “infecting” dependents transitively up to
+the final application.</p>
+<p>For this reason, libraries written in either language cannot rely on
+unwinding for exception safety.</p>
+<p>It is not uncommon, however, for libraries to effectively rely on
+unwinding to occur in order to properly free resources. For example, the
+documentation for the <a
+href="https://docs.rs/easycurses/latest/easycurses/"><code>easycurses</code></a>
+library says:</p>
 <blockquote>
-<p>The library can only perform proper automatic cleanup if Rust is allowed to run the <code>Drop</code> implementation. This happens during normal usage, and during an unwinding panic, but if you ever abort the program (either because you compiled with <code>panic=abort</code> or because you panic during an unwind) you lose the cleanup safety. That is why this library specifies <code>panic="unwind"</code> for all build modes, and you should too.</p>
+<p>The library can only perform proper automatic cleanup if Rust is
+allowed to run the <code>Drop</code> implementation. This happens during
+normal usage, and during an unwinding panic, but if you ever abort the
+program (either because you compiled with <code>panic=abort</code> or
+because you panic during an unwind) you lose the cleanup safety. That is
+why this library specifies <code>panic="unwind"</code> for all build
+modes, and you should too.</p>
 </blockquote>
-<p>This is not a problem with the library, or with Rust. It’s just what it is.</p></li>
-<li><p><strong>Code in General Cannot Rely on Destructors:</strong> A double throw will abort, a stack overflow can abort, and a SIGABRT can abort the program, and, finally, the power cord can be pulled. In all of these cases, destructors will not be called.</p>
-<p>In the presence of exogeneous program termination, the only way to write completely safe code is to use side effects with atomic/transactional semantics.</p></li>
+<p>This is not a problem with the library, or with Rust. It’s just what
+it is.</p></li>
+<li><p><strong>Code in General Cannot Rely on Destructors:</strong> A
+double throw will abort, a stack overflow can abort, and a SIGABRT can
+abort the program, and, finally, the power cord can be pulled. In all of
+these cases, destructors will not be called.</p>
+<p>In the presence of exogeneous program termination, the only way to
+write completely safe code is to use side effects with
+atomic/transactional semantics.</p></li>
 </ol>
 <h3 id="linear-types-exceptions">Linear Types and Exceptions</h3>
-<p>Linear types are incompatible with exception handling. It’s easy to see why.</p>
-<p>A linear type system guarantees all resources allocated by a terminating program will be freed, and none will be used after being freed. This guarantee is lost with the introduction of exceptions: we can throw an exception before the consumer of a linear resource is called, thus leaking the resource. In this section we go through different strategies for reconciling linear types and exceptions.</p>
+<p>Linear types are incompatible with exception handling. It’s easy to
+see why.</p>
+<p>A linear type system guarantees all resources allocated by a
+terminating program will be freed, and none will be used after being
+freed. This guarantee is lost with the introduction of exceptions: we
+can throw an exception before the consumer of a linear resource is
+called, thus leaking the resource. In this section we go through
+different strategies for reconciling linear types and exceptions.</p>
 <h4 id="linear-types-exceptions-example">Motivating Example</h4>
-<p>If you’re convinced that linear types and exceptions don’t work together, skip this section. Otherwise, consider:</p>
-<div class="sourceCode" id="cb57"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true"></a>try {</span>
-<span id="cb57-2"><a href="#cb57-2" aria-hidden="true"></a>  let f = open(<span class="st">&quot;/etc/config&quot;</span>);</span>
-<span id="cb57-3"><a href="#cb57-3" aria-hidden="true"></a>  <span class="co">// `write` consumes `f`, and returns a new linear file object</span></span>
-<span id="cb57-4"><a href="#cb57-4" aria-hidden="true"></a>  let f&#39; = write(f, <span class="st">&quot;Hello, world!&quot;</span>);</span>
-<span id="cb57-5"><a href="#cb57-5" aria-hidden="true"></a>  throw Exception(<span class="st">&quot;Nope&quot;</span>);</span>
-<span id="cb57-6"><a href="#cb57-6" aria-hidden="true"></a>  close(f&#39;);</span>
-<span id="cb57-7"><a href="#cb57-7" aria-hidden="true"></a>} catch Exception {</span>
-<span id="cb57-8"><a href="#cb57-8" aria-hidden="true"></a>  puts(<span class="st">&quot;Leak!&quot;</span>);</span>
-<span id="cb57-9"><a href="#cb57-9" aria-hidden="true"></a>}</span></code></pre></div>
-<p>A linear type system will accept this program: <code>f</code> and <code>f'</code> are both used once. But this program has a resource leak: an exception is thrown before <code>f'</code> is consumed.</p>
-<p>If variables defined in a <code>try</code> block can be used in the scope of the associated <code>catch</code> block, we could attempt a fix:</p>
-<div class="sourceCode" id="cb58"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true"></a>try {</span>
-<span id="cb58-2"><a href="#cb58-2" aria-hidden="true"></a>  let f = open(<span class="st">&quot;/etc/config&quot;</span>);</span>
-<span id="cb58-3"><a href="#cb58-3" aria-hidden="true"></a>  let f&#39; = write(f, <span class="st">&quot;Hello, world!&quot;</span>);</span>
-<span id="cb58-4"><a href="#cb58-4" aria-hidden="true"></a>  throw Exception(<span class="st">&quot;Nope&quot;</span>);</span>
-<span id="cb58-5"><a href="#cb58-5" aria-hidden="true"></a>  close(f&#39;);</span>
-<span id="cb58-6"><a href="#cb58-6" aria-hidden="true"></a>} catch Exception {</span>
-<span id="cb58-7"><a href="#cb58-7" aria-hidden="true"></a>  close(f&#39;);</span>
-<span id="cb58-8"><a href="#cb58-8" aria-hidden="true"></a>}</span></code></pre></div>
-<p>But the type system wouldn’t accept this: <code>f'</code> is potentially being consumed twice, if the exception is thrown from inside <code>close</code>.</p>
-<p>Can we implement exception handling in a linearly-typed language in a way that preserves linearity guarantees? In the next three sections, we look at the possible approaches.</p>
-<h4 id="linear-types-exceptions-values">Solution A: Values, not Exceptions</h4>
-<p>We could try having exception handling only as syntactic sugar over returning values. Instead of implementing a complex exception handling scheme, all potentially-throwing operations return union types. This can be made less onerous through syntactic sugar. The function:</p>
-<div class="sourceCode" id="cb59"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true"></a>T nth(array&lt;T&gt; arr, <span class="dt">size_t</span> index) throws OutOfBounds {</span>
-<span id="cb59-2"><a href="#cb59-2" aria-hidden="true"></a>  <span class="cf">return</span> arr[index];</span>
-<span id="cb59-3"><a href="#cb59-3" aria-hidden="true"></a>}</span></code></pre></div>
+<p>If you’re convinced that linear types and exceptions don’t work
+together, skip this section. Otherwise, consider:</p>
+<div class="sourceCode" id="cb57"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a>try <span class="op">{</span></span>
+<span id="cb57-2"><a href="#cb57-2" aria-hidden="true" tabindex="-1"></a>  let f <span class="op">=</span> open<span class="op">(</span><span class="st">&quot;/etc/config&quot;</span><span class="op">);</span></span>
+<span id="cb57-3"><a href="#cb57-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">// `write` consumes `f`, and returns a new linear file object</span></span>
+<span id="cb57-4"><a href="#cb57-4" aria-hidden="true" tabindex="-1"></a>  let f<span class="ch">&#39; </span><span class="er">= write(f, &quot;Hello, world!&quot;);</span></span>
+<span id="cb57-5"><a href="#cb57-5" aria-hidden="true" tabindex="-1"></a>  throw Exception<span class="op">(</span><span class="st">&quot;Nope&quot;</span><span class="op">);</span></span>
+<span id="cb57-6"><a href="#cb57-6" aria-hidden="true" tabindex="-1"></a>  close<span class="op">(</span>f<span class="ch">&#39;)</span><span class="er">;</span></span>
+<span id="cb57-7"><a href="#cb57-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> catch Exception <span class="op">{</span></span>
+<span id="cb57-8"><a href="#cb57-8" aria-hidden="true" tabindex="-1"></a>  puts<span class="op">(</span><span class="st">&quot;Leak!&quot;</span><span class="op">);</span></span>
+<span id="cb57-9"><a href="#cb57-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>A linear type system will accept this program: <code>f</code> and
+<code>f'</code> are both used once. But this program has a resource
+leak: an exception is thrown before <code>f'</code> is consumed.</p>
+<p>If variables defined in a <code>try</code> block can be used in the
+scope of the associated <code>catch</code> block, we could attempt a
+fix:</p>
+<div class="sourceCode" id="cb58"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a>try <span class="op">{</span></span>
+<span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a>  let f <span class="op">=</span> open<span class="op">(</span><span class="st">&quot;/etc/config&quot;</span><span class="op">);</span></span>
+<span id="cb58-3"><a href="#cb58-3" aria-hidden="true" tabindex="-1"></a>  let f<span class="ch">&#39; </span><span class="er">= write(f, &quot;Hello, world!&quot;);</span></span>
+<span id="cb58-4"><a href="#cb58-4" aria-hidden="true" tabindex="-1"></a>  throw Exception<span class="op">(</span><span class="st">&quot;Nope&quot;</span><span class="op">);</span></span>
+<span id="cb58-5"><a href="#cb58-5" aria-hidden="true" tabindex="-1"></a>  close<span class="op">(</span>f<span class="ch">&#39;)</span><span class="er">;</span></span>
+<span id="cb58-6"><a href="#cb58-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> catch Exception <span class="op">{</span></span>
+<span id="cb58-7"><a href="#cb58-7" aria-hidden="true" tabindex="-1"></a>  close<span class="op">(</span>f<span class="ch">&#39;)</span><span class="er">;</span></span>
+<span id="cb58-8"><a href="#cb58-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>But the type system wouldn’t accept this: <code>f'</code> is
+potentially being consumed twice, if the exception is thrown from inside
+<code>close</code>.</p>
+<p>Can we implement exception handling in a linearly-typed language in a
+way that preserves linearity guarantees? In the next three sections, we
+look at the possible approaches.</p>
+<h4 id="linear-types-exceptions-values">Solution A: Values, not
+Exceptions</h4>
+<p>We could try having exception handling only as syntactic sugar over
+returning values. Instead of implementing a complex exception handling
+scheme, all potentially-throwing operations return union types. This can
+be made less onerous through syntactic sugar. The function:</p>
+<div class="sourceCode" id="cb59"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a>T nth<span class="op">(</span>array<span class="op">&lt;</span>T<span class="op">&gt;</span> arr<span class="op">,</span> <span class="dt">size_t</span> index<span class="op">)</span> throws OutOfBounds <span class="op">{</span></span>
+<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> arr<span class="op">[</span>index<span class="op">];</span></span>
+<span id="cb59-3"><a href="#cb59-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>Can be desugared to (in a vaguely Rust-ish syntax):</p>
-<div class="sourceCode" id="cb60"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true"></a>Result&lt;T, OutOfBounds&gt; nth(array&lt;T&gt; arr, <span class="dt">size_t</span> index) {</span>
-<span id="cb60-2"><a href="#cb60-2" aria-hidden="true"></a>  <span class="cf">case</span> arr[index] {</span>
-<span id="cb60-3"><a href="#cb60-3" aria-hidden="true"></a>    Some(elem: T) =&gt; {</span>
-<span id="cb60-4"><a href="#cb60-4" aria-hidden="true"></a>      <span class="cf">return</span> Result::ok(elem);</span>
-<span id="cb60-5"><a href="#cb60-5" aria-hidden="true"></a>    }</span>
-<span id="cb60-6"><a href="#cb60-6" aria-hidden="true"></a>    None =&gt; {</span>
-<span id="cb60-7"><a href="#cb60-7" aria-hidden="true"></a>      <span class="cf">return</span> Result::error(OutOfBounds());</span>
-<span id="cb60-8"><a href="#cb60-8" aria-hidden="true"></a>    }</span>
-<span id="cb60-9"><a href="#cb60-9" aria-hidden="true"></a>  }</span>
-<span id="cb60-10"><a href="#cb60-10" aria-hidden="true"></a>}</span></code></pre></div>
-<p>This is appealing because much of the hassle of pattern matching <code>Result</code> types can be simplified by the compiler. But this approach is immensely limiting, because as stated above, many fundamental operations have failure modes that have to be handled explicitly:</p>
+<div class="sourceCode" id="cb60"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a>Result<span class="op">&lt;</span>T<span class="op">,</span> OutOfBounds<span class="op">&gt;</span> nth<span class="op">(</span>array<span class="op">&lt;</span>T<span class="op">&gt;</span> arr<span class="op">,</span> <span class="dt">size_t</span> index<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">case</span> arr<span class="op">[</span>index<span class="op">]</span> <span class="op">{</span></span>
+<span id="cb60-3"><a href="#cb60-3" aria-hidden="true" tabindex="-1"></a>    Some<span class="op">(</span>elem<span class="op">:</span> T<span class="op">)</span> <span class="op">=&gt;</span> <span class="op">{</span></span>
+<span id="cb60-4"><a href="#cb60-4" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> Result<span class="op">::</span>ok<span class="op">(</span>elem<span class="op">);</span></span>
+<span id="cb60-5"><a href="#cb60-5" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb60-6"><a href="#cb60-6" aria-hidden="true" tabindex="-1"></a>    None <span class="op">=&gt;</span> <span class="op">{</span></span>
+<span id="cb60-7"><a href="#cb60-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> Result<span class="op">::</span>error<span class="op">(</span>OutOfBounds<span class="op">());</span></span>
+<span id="cb60-8"><a href="#cb60-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb60-9"><a href="#cb60-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb60-10"><a href="#cb60-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>This is appealing because much of the hassle of pattern matching
+<code>Result</code> types can be simplified by the compiler. But this
+approach is immensely limiting, because as stated above, many
+fundamental operations have failure modes that have to be handled
+explicitly:</p>
 <pre><code>add : (Int, Int) -&gt; Result&lt;Int, Overflow&gt;
 sub : (Int, Int) -&gt; Result&lt;Int, Overflow&gt;
 mul : (Int, Int) -&gt; Result&lt;Int, Overflow&gt;
 div : (Int, Int) -&gt; Result&lt;Int, Overflow | DivisionByZero&gt;
 
 nth : (Array&lt;T&gt;, Nat) -&gt; Result&lt;T, OutOfBounds&gt;</code></pre>
-<p>As an example, consider a data structure implementation that uses arrays under the hood. The implementation has been thoroughly tested and you can easily convince yourself that it never accesses an array with an invalid index. But if the array indexing primitive returns an option type to indicate out-of-bounds access, the implementation has to handle this explicitly, and the option type will “leak” into client code, up an arbitrarily deep call stack.</p>
-<p>The problem is that an ML-style type system considers all cases in a union type to be equiprobable, the normal path and the abnormal path have to be given equal consideration in the code. Exception handling systems let us conveniently differentiate between normal and abnormal cases.</p>
-<h4 id="linear-types-exceptions-provers">Solution B: Use Integrated Theorem Provers</h4>
-<p>Instead of implementing exception handling for contract violations, we can use an integrated theorem prover and SMT solver to prove that integer division by zero, integer overflow, array index out of bounds errors, etc. never happen.</p>
-<p>A full treatment of <a href="https://en.wikipedia.org/wiki/Abstract_interpretation">abstract interpretation</a> is beyond the scope of this article. The usual tradeoff applies: the tractable static analysis methods prohibit many ordinary constructions, while the methods sophisticated enough to prove most code correct are extremely difficult to implement completely and correctly. Z3 is 300,000 lines of code.</p>
-<h4 id="linear-types-exceptions-capture">Solution C: Capturing the Linear Environment</h4>
-<p>To our knowledge, this is the only sound approach to doing exception handling in a linearly-typed language that doesn’t involve fanciful constructs using delimited continuations.</p>
-<p><a href="https://link.springer.com/chapter/10.1007/978-3-540-24725-8_15">PacLang</a> is an imperative linearly-typed programming language specifically designed to write packet-processing algorithms for <a href="https://en.wikipedia.org/wiki/Network_processor">network procesors</a>. The paper is worth reading.</p>
+<p>As an example, consider a data structure implementation that uses
+arrays under the hood. The implementation has been thoroughly tested and
+you can easily convince yourself that it never accesses an array with an
+invalid index. But if the array indexing primitive returns an option
+type to indicate out-of-bounds access, the implementation has to handle
+this explicitly, and the option type will “leak” into client code, up an
+arbitrarily deep call stack.</p>
+<p>The problem is that an ML-style type system considers all cases in a
+union type to be equiprobable, the normal path and the abnormal path
+have to be given equal consideration in the code. Exception handling
+systems let us conveniently differentiate between normal and abnormal
+cases.</p>
+<h4 id="linear-types-exceptions-provers">Solution B: Use Integrated
+Theorem Provers</h4>
+<p>Instead of implementing exception handling for contract violations,
+we can use an integrated theorem prover and SMT solver to prove that
+integer division by zero, integer overflow, array index out of bounds
+errors, etc. never happen.</p>
+<p>A full treatment of <a
+href="https://en.wikipedia.org/wiki/Abstract_interpretation">abstract
+interpretation</a> is beyond the scope of this article. The usual
+tradeoff applies: the tractable static analysis methods prohibit many
+ordinary constructions, while the methods sophisticated enough to prove
+most code correct are extremely difficult to implement completely and
+correctly. Z3 is 300,000 lines of code.</p>
+<h4 id="linear-types-exceptions-capture">Solution C: Capturing the
+Linear Environment</h4>
+<p>To our knowledge, this is the only sound approach to doing exception
+handling in a linearly-typed language that doesn’t involve fanciful
+constructs using delimited continuations.</p>
+<p><a
+href="https://link.springer.com/chapter/10.1007/978-3-540-24725-8_15">PacLang</a>
+is an imperative linearly-typed programming language specifically
+designed to write packet-processing algorithms for <a
+href="https://en.wikipedia.org/wiki/Network_processor">network
+procesors</a>. The paper is worth reading.</p>
 <p>Its authors describe the language as:</p>
 <blockquote>
-<p>a simple, first order, call by value language, intended for constructing network packet processing programs. It resembles and behaves like C in most respects. The distinctive feature of PacLang is its type system, treating the datatypes that correspond to network packets within the program as linear types. The target platforms are application-specific network processor (NP) architectures such as the Intel IXP range and the IBM PowerNP.</p>
+<p>a simple, first order, call by value language, intended for
+constructing network packet processing programs. It resembles and
+behaves like C in most respects. The distinctive feature of PacLang is
+its type system, treating the datatypes that correspond to network
+packets within the program as linear types. The target platforms are
+application-specific network processor (NP) architectures such as the
+Intel IXP range and the IBM PowerNP.</p>
 </blockquote>
-<p>The type system is straightforward: <code>bool</code>, <code>int</code>, and a linear <code>packet</code> type. A limited form of borrowing is supported, with the usual semantics:</p>
+<p>The type system is straightforward: <code>bool</code>,
+<code>int</code>, and a linear <code>packet</code> type. A limited form
+of borrowing is supported, with the usual semantics:</p>
 <blockquote>
-<p>In PacLang, the only linear reference is a <code>packet</code>. An <em>alias</em> to a reference of this type, a <code>!packet</code>, can be created in a limited scope, by casting a <code>packet</code> into a <code>!packet</code> if used as a function argument whose signature requires a <code>!packet</code>. An alias may never exist without an owning reference, and cannot be created from scratch. In the scope of that function, and other functions applied to the same <code>!packet</code>, the alias can behave as a normal non-linear value, but is not allowed to co-exist in the same scope as the owning reference <code>packet</code>. This is enforced with constraints in the type system:</p>
+<p>In PacLang, the only linear reference is a <code>packet</code>. An
+<em>alias</em> to a reference of this type, a <code>!packet</code>, can
+be created in a limited scope, by casting a <code>packet</code> into a
+<code>!packet</code> if used as a function argument whose signature
+requires a <code>!packet</code>. An alias may never exist without an
+owning reference, and cannot be created from scratch. In the scope of
+that function, and other functions applied to the same
+<code>!packet</code>, the alias can behave as a normal non-linear value,
+but is not allowed to co-exist in the same scope as the owning reference
+<code>packet</code>. This is enforced with constraints in the type
+system:</p>
 <ul>
-<li><p>A <code>!packet</code> may not be returned from a function, as otherwise it would be possible for it to co-exist inscope with the owning <code>packet</code></p></li>
-<li><p>A <code>!packet</code> may not be passed into a function as an argument where the owning <code>packet</code> is also being used as an argument, for the same reason</p></li>
+<li><p>A <code>!packet</code> may not be returned from a function, as
+otherwise it would be possible for it to co-exist inscope with the
+owning <code>packet</code></p></li>
+<li><p>A <code>!packet</code> may not be passed into a function as an
+argument where the owning <code>packet</code> is also being used as an
+argument, for the same reason</p></li>
 </ul>
-<p>Any function taking a <code>!packet</code> cannot presume to “own” the value it aliases, so is not permitted to deallocate it or pass it to another a thread; this is enforced by the signatures of the relevant primitive functions. The constraints on the <code>packet</code> and <code>!packet</code> reference types combined with the primitives for inter-thread communication give a <em>uniqueness guarantee</em> that only one thread will ever have reference to a packet.</p>
+<p>Any function taking a <code>!packet</code> cannot presume to “own”
+the value it aliases, so is not permitted to deallocate it or pass it to
+another a thread; this is enforced by the signatures of the relevant
+primitive functions. The constraints on the <code>packet</code> and
+<code>!packet</code> reference types combined with the primitives for
+inter-thread communication give a <em>uniqueness guarantee</em> that
+only one thread will ever have reference to a packet.</p>
 </blockquote>
-<p>An interesting restriction is that much of the language has to be written in <a href="https://en.wikipedia.org/wiki/A-normal_form">A-normal form</a> to simplify type checking. This is sound: extending a linear type system to implement convenience features like borrowing is made simpler by working with variables rather than arbitrary expressions, and it’s a restriction Austral shares.</p>
-<p>The original language has no exception handling system. PacLang++, a successor with exception handling support, is introduced in the paper <em>Memory safety with exceptions and linear types</em>. The paper is difficult to find, so I will quote from it often. The authors first describe their motivation in adding exception handling:</p>
+<p>An interesting restriction is that much of the language has to be
+written in <a
+href="https://en.wikipedia.org/wiki/A-normal_form">A-normal form</a> to
+simplify type checking. This is sound: extending a linear type system to
+implement convenience features like borrowing is made simpler by working
+with variables rather than arbitrary expressions, and it’s a restriction
+Austral shares.</p>
+<p>The original language has no exception handling system. PacLang++, a
+successor with exception handling support, is introduced in the paper
+<em>Memory safety with exceptions and linear types</em>. The paper is
+difficult to find, so I will quote from it often. The authors first
+describe their motivation in adding exception handling:</p>
 <blockquote>
-<p>In our experience of practical PacLang programming, an issue commonly arising is that of functions returning error values. The usual solution has been to return an unused integer value (C libraries commonly use -1 for this practice) where the function returns an integer, or to add a boolean to the return tuple signalling the presence of an error or other unusual situation. This quickly becomes awkward and ugly, especially when the error condition needs to be passed up several levels in the call graph. Additionally, it is far easier for a programmer to unintentionally ignore errors using this method, resulting in less obvious errors later in the program, for example a programmer takes the return value as valid data, complacently ignoring the possibility of an error, and using that error value where valid data is expected later in the program.</p>
+<p>In our experience of practical PacLang programming, an issue commonly
+arising is that of functions returning error values. The usual solution
+has been to return an unused integer value (C libraries commonly use -1
+for this practice) where the function returns an integer, or to add a
+boolean to the return tuple signalling the presence of an error or other
+unusual situation. This quickly becomes awkward and ugly, especially
+when the error condition needs to be passed up several levels in the
+call graph. Additionally, it is far easier for a programmer to
+unintentionally ignore errors using this method, resulting in less
+obvious errors later in the program, for example a programmer takes the
+return value as valid data, complacently ignoring the possibility of an
+error, and using that error value where valid data is expected later in
+the program.</p>
 </blockquote>
 <p>The linear type system of PacLang:</p>
 <blockquote>
-<p>A linearly typed reference (in PacLang this is known as the owning reference, though other kinds of non-linear packet references will be covered later) is one that can be used <em>only once</em> along each execution path, making subsequent uses a type error; the type system supports this by removing a reference (<em>consuming</em> it) from the environment after use. As copying a linear reference <em>consumes</em> it, only one reference (the <em>owning</em> reference) to the packet may exist at any point in the program’s runtime. Furthermore, a linear reference <em>must</em> be used once and only once, guaranteeing that any linearly referenced value in a type safe program that halts will be consumed eventually.</p>
+<p>A linearly typed reference (in PacLang this is known as the owning
+reference, though other kinds of non-linear packet references will be
+covered later) is one that can be used <em>only once</em> along each
+execution path, making subsequent uses a type error; the type system
+supports this by removing a reference (<em>consuming</em> it) from the
+environment after use. As copying a linear reference <em>consumes</em>
+it, only one reference (the <em>owning</em> reference) to the packet may
+exist at any point in the program’s runtime. Furthermore, a linear
+reference <em>must</em> be used once and only once, guaranteeing that
+any linearly referenced value in a type safe program that halts will be
+consumed eventually.</p>
 </blockquote>
-<p>The authors first discuss the exceptions as values approach, discarding it because it doesn’t support intra-function exception handling, and requires all functions to deallocate live linear values before throwing. The second attempt is described by the authors:</p>
+<p>The authors first discuss the exceptions as values approach,
+discarding it because it doesn’t support intra-function exception
+handling, and requires all functions to deallocate live linear values
+before throwing. The second attempt is described by the authors:</p>
 <blockquote>
-<p>At the time an exception is raised, any packets in scope must be consumed through being used as an argument to the exception constructor, being “carried” by the exception and coming into the scope of the block that catches the exception.</p>
+<p>At the time an exception is raised, any packets in scope must be
+consumed through being used as an argument to the exception constructor,
+being “carried” by the exception and coming into the scope of the block
+that catches the exception.</p>
 </blockquote>
 <p>This is also rejected, because:</p>
 <blockquote>
-<p>this method does not account for live packets that are not in scope at the time an exception is raised. An exception can pass arbitrarily far up the call graph through multiple scopes that may contain live packets until it is caught.</p>
+<p>this method does not account for live packets that are not in scope
+at the time an exception is raised. An exception can pass arbitrarily
+far up the call graph through multiple scopes that may contain live
+packets until it is caught.</p>
 </blockquote>
 <p>The third and final approach:</p>
 <blockquote>
-<p>We create an enhanced version of the original PacLang type system, which brings linear references into the environment implicitly wherever an exception is caught. Our type system ensures that the environment starting a catch block will contain a set of references (that are in the scope of the exception handling block) to the <em>exact same</em> linear references that were live at the instant the exception was thrown.</p>
+<p>We create an enhanced version of the original PacLang type system,
+which brings linear references into the environment implicitly wherever
+an exception is caught. Our type system ensures that the environment
+starting a catch block will contain a set of references (that are in the
+scope of the exception handling block) to the <em>exact same</em> linear
+references that were live at the instant the exception was thrown.</p>
 </blockquote>
-<p>To illustrate I adapted the following example from the paper, adding a few more comments:</p>
-<div class="sourceCode" id="cb62"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true"></a>packet x = recv();</span>
-<span id="cb62-2"><a href="#cb62-2" aria-hidden="true"></a>packet y = recv();</span>
-<span id="cb62-3"><a href="#cb62-3" aria-hidden="true"></a></span>
-<span id="cb62-4"><a href="#cb62-4" aria-hidden="true"></a><span class="co">// At this point, the environment is {x, y}</span></span>
-<span id="cb62-5"><a href="#cb62-5" aria-hidden="true"></a></span>
-<span id="cb62-6"><a href="#cb62-6" aria-hidden="true"></a>try {</span>
-<span id="cb62-7"><a href="#cb62-7" aria-hidden="true"></a>  consume(x);</span>
-<span id="cb62-8"><a href="#cb62-8" aria-hidden="true"></a>  <span class="co">// At this point, the environment is just {y}</span></span>
-<span id="cb62-9"><a href="#cb62-9" aria-hidden="true"></a>  <span class="cf">if</span> (check(!y)) {</span>
-<span id="cb62-10"><a href="#cb62-10" aria-hidden="true"></a>    consume(y);</span>
-<span id="cb62-11"><a href="#cb62-11" aria-hidden="true"></a>    <span class="co">// Here, the environment is {}</span></span>
-<span id="cb62-12"><a href="#cb62-12" aria-hidden="true"></a>  } <span class="cf">else</span> {</span>
-<span id="cb62-13"><a href="#cb62-13" aria-hidden="true"></a>    throw Error; <span class="co">// Consumes y implicitly</span></span>
-<span id="cb62-14"><a href="#cb62-14" aria-hidden="true"></a>    <span class="co">// Here, the environment is {}</span></span>
-<span id="cb62-15"><a href="#cb62-15" aria-hidden="true"></a>  }</span>
-<span id="cb62-16"><a href="#cb62-16" aria-hidden="true"></a>  <span class="co">// Both branches end with the same environment</span></span>
-<span id="cb62-17"><a href="#cb62-17" aria-hidden="true"></a>} catch Error(packet y) {</span>
-<span id="cb62-18"><a href="#cb62-18" aria-hidden="true"></a>  log_error();</span>
-<span id="cb62-19"><a href="#cb62-19" aria-hidden="true"></a>  consume(y);</span>
-<span id="cb62-20"><a href="#cb62-20" aria-hidden="true"></a>}</span></code></pre></div>
-<p>The authors go on to explain a limitation of this scheme: if two different <code>throw</code> sites have a different environment, the program won’t type check. For example:</p>
-<div class="sourceCode" id="cb63"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true"></a>packet x = recv();</span>
-<span id="cb63-2"><a href="#cb63-2" aria-hidden="true"></a></span>
-<span id="cb63-3"><a href="#cb63-3" aria-hidden="true"></a><span class="co">// Environment is {x}</span></span>
-<span id="cb63-4"><a href="#cb63-4" aria-hidden="true"></a><span class="cf">if</span> (check(!x)) {</span>
-<span id="cb63-5"><a href="#cb63-5" aria-hidden="true"></a>  packet y = recv();</span>
-<span id="cb63-6"><a href="#cb63-6" aria-hidden="true"></a></span>
-<span id="cb63-7"><a href="#cb63-7" aria-hidden="true"></a>  <span class="co">// Environment is {x, y}</span></span>
-<span id="cb63-8"><a href="#cb63-8" aria-hidden="true"></a>  <span class="cf">if</span> (checkBoth(!x, !y)) {</span>
-<span id="cb63-9"><a href="#cb63-9" aria-hidden="true"></a>    consume(x);</span>
-<span id="cb63-10"><a href="#cb63-10" aria-hidden="true"></a>    consume(y);</span>
-<span id="cb63-11"><a href="#cb63-11" aria-hidden="true"></a>    <span class="co">// Environment is {}</span></span>
-<span id="cb63-12"><a href="#cb63-12" aria-hidden="true"></a>  } <span class="cf">else</span> {</span>
-<span id="cb63-13"><a href="#cb63-13" aria-hidden="true"></a>    throw Error; <span class="co">// Consumes x and y</span></span>
-<span id="cb63-14"><a href="#cb63-14" aria-hidden="true"></a>    <span class="co">// Environment is {}</span></span>
-<span id="cb63-15"><a href="#cb63-15" aria-hidden="true"></a>  }</span>
-<span id="cb63-16"><a href="#cb63-16" aria-hidden="true"></a>} <span class="cf">else</span> {</span>
-<span id="cb63-17"><a href="#cb63-17" aria-hidden="true"></a>  throw Error; <span class="co">// Consumes x</span></span>
-<span id="cb63-18"><a href="#cb63-18" aria-hidden="true"></a>  <span class="co">// Enviroment is {}</span></span>
-<span id="cb63-19"><a href="#cb63-19" aria-hidden="true"></a>}</span></code></pre></div>
-<p>While the code is locally sound, one <code>throw</code> site captures <code>x</code> alone while one captures <code>x</code> and <code>y</code>.</p>
-<p>Suppose the language we’re working with requires functions to be annotated with an exception signature, along the lines of [checked exceptions][checked]. Then, if all throw sites in a function <code>f</code> implicitly capture a single linear packet variable, we can annotate the function this way:</p>
-<div class="sourceCode" id="cb64"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true"></a><span class="dt">void</span> f() throws Error(packet x)</span></code></pre></div>
-<p>But in the above code example, the exception annotation is ambiguous, because different throw sites capture different environments:</p>
-<div class="sourceCode" id="cb65"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true"></a><span class="dt">void</span> f() throws Error(packet x)</span>
-<span id="cb65-2"><a href="#cb65-2" aria-hidden="true"></a><span class="co">// Or</span></span>
-<span id="cb65-3"><a href="#cb65-3" aria-hidden="true"></a><span class="dt">void</span> f() throws Error(packet x, packet y)</span></code></pre></div>
-<p>Choosing the former leaks <code>y</code>, and choosing the latter means the value of <code>y</code> will be undefined in some cases.</p>
-<p>This can be fixed with the use of option types: because environments form a partially ordered set, we can use option types to represent bindings which are not available at every <code>throw</code> site. In the code example above, we have:</p>
+<p>To illustrate I adapted the following example from the paper, adding
+a few more comments:</p>
+<div class="sourceCode" id="cb62"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a>packet x <span class="op">=</span> recv<span class="op">();</span></span>
+<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>packet y <span class="op">=</span> recv<span class="op">();</span></span>
+<span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb62-4"><a href="#cb62-4" aria-hidden="true" tabindex="-1"></a><span class="co">// At this point, the environment is {x, y}</span></span>
+<span id="cb62-5"><a href="#cb62-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb62-6"><a href="#cb62-6" aria-hidden="true" tabindex="-1"></a>try <span class="op">{</span></span>
+<span id="cb62-7"><a href="#cb62-7" aria-hidden="true" tabindex="-1"></a>  consume<span class="op">(</span>x<span class="op">);</span></span>
+<span id="cb62-8"><a href="#cb62-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">// At this point, the environment is just {y}</span></span>
+<span id="cb62-9"><a href="#cb62-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>check<span class="op">(!</span>y<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb62-10"><a href="#cb62-10" aria-hidden="true" tabindex="-1"></a>    consume<span class="op">(</span>y<span class="op">);</span></span>
+<span id="cb62-11"><a href="#cb62-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Here, the environment is {}</span></span>
+<span id="cb62-12"><a href="#cb62-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb62-13"><a href="#cb62-13" aria-hidden="true" tabindex="-1"></a>    throw Error<span class="op">;</span> <span class="co">// Consumes y implicitly</span></span>
+<span id="cb62-14"><a href="#cb62-14" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Here, the environment is {}</span></span>
+<span id="cb62-15"><a href="#cb62-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb62-16"><a href="#cb62-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Both branches end with the same environment</span></span>
+<span id="cb62-17"><a href="#cb62-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> catch Error<span class="op">(</span>packet y<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb62-18"><a href="#cb62-18" aria-hidden="true" tabindex="-1"></a>  log_error<span class="op">();</span></span>
+<span id="cb62-19"><a href="#cb62-19" aria-hidden="true" tabindex="-1"></a>  consume<span class="op">(</span>y<span class="op">);</span></span>
+<span id="cb62-20"><a href="#cb62-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>The authors go on to explain a limitation of this scheme: if two
+different <code>throw</code> sites have a different environment, the
+program won’t type check. For example:</p>
+<div class="sourceCode" id="cb63"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>packet x <span class="op">=</span> recv<span class="op">();</span></span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a><span class="co">// Environment is {x}</span></span>
+<span id="cb63-4"><a href="#cb63-4" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>check<span class="op">(!</span>x<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb63-5"><a href="#cb63-5" aria-hidden="true" tabindex="-1"></a>  packet y <span class="op">=</span> recv<span class="op">();</span></span>
+<span id="cb63-6"><a href="#cb63-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb63-7"><a href="#cb63-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Environment is {x, y}</span></span>
+<span id="cb63-8"><a href="#cb63-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>checkBoth<span class="op">(!</span>x<span class="op">,</span> <span class="op">!</span>y<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb63-9"><a href="#cb63-9" aria-hidden="true" tabindex="-1"></a>    consume<span class="op">(</span>x<span class="op">);</span></span>
+<span id="cb63-10"><a href="#cb63-10" aria-hidden="true" tabindex="-1"></a>    consume<span class="op">(</span>y<span class="op">);</span></span>
+<span id="cb63-11"><a href="#cb63-11" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Environment is {}</span></span>
+<span id="cb63-12"><a href="#cb63-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb63-13"><a href="#cb63-13" aria-hidden="true" tabindex="-1"></a>    throw Error<span class="op">;</span> <span class="co">// Consumes x and y</span></span>
+<span id="cb63-14"><a href="#cb63-14" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Environment is {}</span></span>
+<span id="cb63-15"><a href="#cb63-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb63-16"><a href="#cb63-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb63-17"><a href="#cb63-17" aria-hidden="true" tabindex="-1"></a>  throw Error<span class="op">;</span> <span class="co">// Consumes x</span></span>
+<span id="cb63-18"><a href="#cb63-18" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Enviroment is {}</span></span>
+<span id="cb63-19"><a href="#cb63-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>While the code is locally sound, one <code>throw</code> site captures
+<code>x</code> alone while one captures <code>x</code> and
+<code>y</code>.</p>
+<p>Suppose the language we’re working with requires functions to be
+annotated with an exception signature, along the lines of [checked
+exceptions][checked]. Then, if all throw sites in a function
+<code>f</code> implicitly capture a single linear packet variable, we
+can annotate the function this way:</p>
+<div class="sourceCode" id="cb64"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> throws Error<span class="op">(</span>packet x<span class="op">)</span></span></code></pre></div>
+<p>But in the above code example, the exception annotation is ambiguous,
+because different throw sites capture different environments:</p>
+<div class="sourceCode" id="cb65"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> throws Error<span class="op">(</span>packet x<span class="op">)</span></span>
+<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a><span class="co">// Or</span></span>
+<span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> throws Error<span class="op">(</span>packet x<span class="op">,</span> packet y<span class="op">)</span></span></code></pre></div>
+<p>Choosing the former leaks <code>y</code>, and choosing the latter
+means the value of <code>y</code> will be undefined in some cases.</p>
+<p>This can be fixed with the use of option types: because environments
+form a partially ordered set, we can use option types to represent
+bindings which are not available at every <code>throw</code> site. In
+the code example above, we have:</p>
 <pre><code>{} &lt; {x} &lt; {x, y}</code></pre>
 <p>So the signature for this function is simply:</p>
-<div class="sourceCode" id="cb67"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true"></a><span class="dt">void</span> f() throws Error(packet x, option&lt;packet&gt; y)</span></code></pre></div>
-<p>In short: we can do it, but it really is just extra semantics and complexity for what is essentially using a <code>Result</code> type.</p>
+<div class="sourceCode" id="cb67"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> throws Error<span class="op">(</span>packet x<span class="op">,</span> option<span class="op">&lt;</span>packet<span class="op">&gt;</span> y<span class="op">)</span></span></code></pre></div>
+<p>In short: we can do it, but it really is just extra semantics and
+complexity for what is essentially using a <code>Result</code> type.</p>
 <h3 id="linear-types-exceptions-affine">Affine Types and Exceptions</h3>
-<p>Affine types are a weakening of linear types, essentially linear types with implicit destructors. In a linear type system, values of a linear type must be used exactly once. In an affine type system, values of an affine type can be used at most once. If they are unused, the compiler automatically inserts a destructor call.</p>
-<p><a href="https://www.rust-lang.org/">Rust</a> does this, and there are good reasons to prefer affine types over linear types:</p>
+<p>Affine types are a weakening of linear types, essentially linear
+types with implicit destructors. In a linear type system, values of a
+linear type must be used exactly once. In an affine type system, values
+of an affine type can be used at most once. If they are unused, the
+compiler automatically inserts a destructor call.</p>
+<p><a href="https://www.rust-lang.org/">Rust</a> does this, and there
+are good reasons to prefer affine types over linear types:</p>
 <ol type="1">
-<li><p>Less typing, since there is no need to explicitly call destructors.</p></li>
-<li><p>Often, compilation fails because programmers make trivial mistakes, such as forgetting a semicolon. A similar mistake is forgetting to insert destructor calls. This isn’t possible with affine types, where the compiler handles object destruction for the programmer.</p></li>
+<li><p>Less typing, since there is no need to explicitly call
+destructors.</p></li>
+<li><p>Often, compilation fails because programmers make trivial
+mistakes, such as forgetting a semicolon. A similar mistake is
+forgetting to insert destructor calls. This isn’t possible with affine
+types, where the compiler handles object destruction for the
+programmer.</p></li>
 <li><p>Destruction order is consistent and well-defined.</p></li>
-<li><p>Most linear types have a single natural destructor function: pointers are deallocated, file handles are closed, database connections are closed, etc. Affine types formalize this practice: instead of having a constellation of ad-hoc destructor functions (<code>deallocate</code>, <code>closeFile</code>, <code>closeDatabase</code>, <code>hangUp</code>), all destructors are presented behind a uniform interface: a generic function of type <code>T! -&gt; Unit</code>.</p></li>
+<li><p>Most linear types have a single natural destructor function:
+pointers are deallocated, file handles are closed, database connections
+are closed, etc. Affine types formalize this practice: instead of having
+a constellation of ad-hoc destructor functions (<code>deallocate</code>,
+<code>closeFile</code>, <code>closeDatabase</code>,
+<code>hangUp</code>), all destructors are presented behind a uniform
+interface: a generic function of type
+<code>T! -&gt; Unit</code>.</p></li>
 </ol>
-<p>The drawbacks of affine types are the same as those of destructors in languages like C++ and <a href="https://www.adaic.org/resources/add_content/docs/95style/html/sec_9/9-2-3.html">Ada</a>, that is:</p>
+<p>The drawbacks of affine types are the same as those of destructors in
+languages like C++ and <a
+href="https://www.adaic.org/resources/add_content/docs/95style/html/sec_9/9-2-3.html">Ada</a>,
+that is:</p>
 <ol type="1">
-<li><p>The use of destructors requires compiler insertion of implicit function calls, which have an invisible cost in runtime and code size, whereas linear types make this cost visible.</p></li>
-<li><p>Destruction order has to be well-specified. For stack-allocated variables, this is straghtforward: destructors are called in inverse declaration order. For temporaries, this is complicated.</p></li>
+<li><p>The use of destructors requires compiler insertion of implicit
+function calls, which have an invisible cost in runtime and code size,
+whereas linear types make this cost visible.</p></li>
+<li><p>Destruction order has to be well-specified. For stack-allocated
+variables, this is straghtforward: destructors are called in inverse
+declaration order. For temporaries, this is complicated.</p></li>
 </ol>
-<p>Additionally, destroying values we don’t do anything with could lead to bugs if the programmer simply forgets about a value they were supposed to use, and instead of warning them, the compiler cleans it up.</p>
-<p>But there is a benefit to using affine types with destructors: exception handling integrates perfectly well. Again, Rust does this: <a href="https://doc.rust-lang.org/std/macro.panic.html"><code>panic</code></a> and <a href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a> are similar to <code>try</code> and <code>catch</code>, and destructors are called by unwinding the stack and calling <code>drop</code> on every affine object. The result is that exceptions are safe: in the happy path, destructors are called by the compiler. In the throwing path, the compiler ensures the destructors are called anyways.</p>
+<p>Additionally, destroying values we don’t do anything with could lead
+to bugs if the programmer simply forgets about a value they were
+supposed to use, and instead of warning them, the compiler cleans it
+up.</p>
+<p>But there is a benefit to using affine types with destructors:
+exception handling integrates perfectly well. Again, Rust does this: <a
+href="https://doc.rust-lang.org/std/macro.panic.html"><code>panic</code></a>
+and <a
+href="https://doc.rust-lang.org/std/panic/fn.catch_unwind.html"><code>catch_unwind</code></a>
+are similar to <code>try</code> and <code>catch</code>, and destructors
+are called by unwinding the stack and calling <code>drop</code> on every
+affine object. The result is that exceptions are safe: in the happy
+path, destructors are called by the compiler. In the throwing path, the
+compiler ensures the destructors are called anyways.</p>
 <p>The implementation strategy is simple:</p>
 <ol type="1">
-<li><p>When the compiler sees a <code>throw</code> expression, it emits calls to the destructor of every (live) affine variable in the environment before emitting the unwinding code.</p>
-<p>That is, given an expression <code>throw(...)</code>, where the affine environment up to that expression is <code>{x, y, z}</code>, the expression is transformed into:</p>
+<li><p>When the compiler sees a <code>throw</code> expression, it emits
+calls to the destructor of every (live) affine variable in the
+environment before emitting the unwinding code.</p>
+<p>That is, given an expression <code>throw(...)</code>, where the
+affine environment up to that expression is <code>{x, y, z}</code>, the
+expression is transformed into:</p>
 <pre><code>free(x);
 free(y);
 free(z);
 throw(...);</code></pre></li>
-<li><p>When the compiler sees a call to a potentially-throwing function (as determined by an <a href="https://en.wikipedia.org/wiki/Effect_system">effect system</a>), it emits a <code>try</code>/<code>catch</code> block: normal excecution proceeds normally, but if an exception is caught, the the destructors of all live affine variables are called, and the exception is re-thrown.</p>
-<p>Suppose we have a function call <code>f()</code>, where the affine environment up to the point of that call is <code>{x, y}</code>. If the function potentially throws an exception, the function call gets rewritten to something like this:</p>
+<li><p>When the compiler sees a call to a potentially-throwing function
+(as determined by an <a
+href="https://en.wikipedia.org/wiki/Effect_system">effect system</a>),
+it emits a <code>try</code>/<code>catch</code> block: normal excecution
+proceeds normally, but if an exception is caught, the the destructors of
+all live affine variables are called, and the exception is
+re-thrown.</p>
+<p>Suppose we have a function call <code>f()</code>, where the affine
+environment up to the point of that call is <code>{x, y}</code>. If the
+function potentially throws an exception, the function call gets
+rewritten to something like this:</p>
 <pre><code>let result = try {
   f();
 } catch Exception as e {
@@ -1067,69 +2196,106 @@ throw(...);</code></pre></li>
 }</code></pre></li>
 </ol>
 <p>For a more complete example, a program like this:</p>
-<div class="sourceCode" id="cb70"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true"></a><span class="dt">void</span> f() throws {</span>
-<span id="cb70-2"><a href="#cb70-2" aria-hidden="true"></a>  let x: string* = allocate(<span class="st">&quot;A fresh affine variable&quot;</span>);</span>
-<span id="cb70-3"><a href="#cb70-3" aria-hidden="true"></a>  <span class="co">// Environment is {x}</span></span>
-<span id="cb70-4"><a href="#cb70-4" aria-hidden="true"></a>  g(x); <span class="co">// Environment is {}</span></span>
-<span id="cb70-5"><a href="#cb70-5" aria-hidden="true"></a>}</span>
-<span id="cb70-6"><a href="#cb70-6" aria-hidden="true"></a></span>
-<span id="cb70-7"><a href="#cb70-7" aria-hidden="true"></a><span class="dt">void</span> g(string* ptr) throws {</span>
-<span id="cb70-8"><a href="#cb70-8" aria-hidden="true"></a>  let y: string* = allocate(<span class="st">&quot;Another heap-allocated string&quot;</span>);</span>
-<span id="cb70-9"><a href="#cb70-9" aria-hidden="true"></a>  <span class="co">// Environment is {ptr, y}</span></span>
-<span id="cb70-10"><a href="#cb70-10" aria-hidden="true"></a>  h(ptr); <span class="co">// Environment is {y}</span></span>
-<span id="cb70-11"><a href="#cb70-11" aria-hidden="true"></a>}</span>
-<span id="cb70-12"><a href="#cb70-12" aria-hidden="true"></a></span>
-<span id="cb70-13"><a href="#cb70-13" aria-hidden="true"></a><span class="dt">void</span> h(string* ptr) throws {</span>
-<span id="cb70-14"><a href="#cb70-14" aria-hidden="true"></a>  let z = allocate(<span class="dv">1234</span>);</span>
-<span id="cb70-15"><a href="#cb70-15" aria-hidden="true"></a>  <span class="cf">if</span> (randBool()) {</span>
-<span id="cb70-16"><a href="#cb70-16" aria-hidden="true"></a>    throw <span class="st">&quot;Halt&quot;</span>;</span>
-<span id="cb70-17"><a href="#cb70-17" aria-hidden="true"></a>  }</span>
-<span id="cb70-18"><a href="#cb70-18" aria-hidden="true"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb70"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> throws <span class="op">{</span></span>
+<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a>  let x<span class="op">:</span> string<span class="op">*</span> <span class="op">=</span> allocate<span class="op">(</span><span class="st">&quot;A fresh affine variable&quot;</span><span class="op">);</span></span>
+<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Environment is {x}</span></span>
+<span id="cb70-4"><a href="#cb70-4" aria-hidden="true" tabindex="-1"></a>  g<span class="op">(</span>x<span class="op">);</span> <span class="co">// Environment is {}</span></span>
+<span id="cb70-5"><a href="#cb70-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb70-6"><a href="#cb70-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb70-7"><a href="#cb70-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> g<span class="op">(</span>string<span class="op">*</span> ptr<span class="op">)</span> throws <span class="op">{</span></span>
+<span id="cb70-8"><a href="#cb70-8" aria-hidden="true" tabindex="-1"></a>  let y<span class="op">:</span> string<span class="op">*</span> <span class="op">=</span> allocate<span class="op">(</span><span class="st">&quot;Another heap-allocated string&quot;</span><span class="op">);</span></span>
+<span id="cb70-9"><a href="#cb70-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Environment is {ptr, y}</span></span>
+<span id="cb70-10"><a href="#cb70-10" aria-hidden="true" tabindex="-1"></a>  h<span class="op">(</span>ptr<span class="op">);</span> <span class="co">// Environment is {y}</span></span>
+<span id="cb70-11"><a href="#cb70-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb70-12"><a href="#cb70-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb70-13"><a href="#cb70-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> h<span class="op">(</span>string<span class="op">*</span> ptr<span class="op">)</span> throws <span class="op">{</span></span>
+<span id="cb70-14"><a href="#cb70-14" aria-hidden="true" tabindex="-1"></a>  let z <span class="op">=</span> allocate<span class="op">(</span><span class="dv">1234</span><span class="op">);</span></span>
+<span id="cb70-15"><a href="#cb70-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>randBool<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb70-16"><a href="#cb70-16" aria-hidden="true" tabindex="-1"></a>    throw <span class="st">&quot;Halt&quot;</span><span class="op">;</span></span>
+<span id="cb70-17"><a href="#cb70-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb70-18"><a href="#cb70-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>Would transform to something like this:</p>
-<div class="sourceCode" id="cb71"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true"></a><span class="dt">void</span> f() {</span>
-<span id="cb71-2"><a href="#cb71-2" aria-hidden="true"></a>  let x: string* = _allocate_str(<span class="st">&quot;A fresh affine variable&quot;</span>);</span>
-<span id="cb71-3"><a href="#cb71-3" aria-hidden="true"></a>  try {</span>
-<span id="cb71-4"><a href="#cb71-4" aria-hidden="true"></a>    g(x);</span>
-<span id="cb71-5"><a href="#cb71-5" aria-hidden="true"></a>  } catch {</span>
-<span id="cb71-6"><a href="#cb71-6" aria-hidden="true"></a>    rethrow;</span>
-<span id="cb71-7"><a href="#cb71-7" aria-hidden="true"></a>  }</span>
-<span id="cb71-8"><a href="#cb71-8" aria-hidden="true"></a>}</span>
-<span id="cb71-9"><a href="#cb71-9" aria-hidden="true"></a></span>
-<span id="cb71-10"><a href="#cb71-10" aria-hidden="true"></a><span class="dt">void</span> g(string* ptr) {</span>
-<span id="cb71-11"><a href="#cb71-11" aria-hidden="true"></a>  let y: string* = _allocate_str(<span class="st">&quot;Another heap-allocated string&quot;</span>);</span>
-<span id="cb71-12"><a href="#cb71-12" aria-hidden="true"></a>  try {</span>
-<span id="cb71-13"><a href="#cb71-13" aria-hidden="true"></a>    h(ptr);</span>
-<span id="cb71-14"><a href="#cb71-14" aria-hidden="true"></a>  } catch {</span>
-<span id="cb71-15"><a href="#cb71-15" aria-hidden="true"></a>    _free_str(y);</span>
-<span id="cb71-16"><a href="#cb71-16" aria-hidden="true"></a>    rethrow;</span>
-<span id="cb71-17"><a href="#cb71-17" aria-hidden="true"></a>  }</span>
-<span id="cb71-18"><a href="#cb71-18" aria-hidden="true"></a>  _free_str(y);</span>
-<span id="cb71-19"><a href="#cb71-19" aria-hidden="true"></a>}</span>
-<span id="cb71-20"><a href="#cb71-20" aria-hidden="true"></a></span>
-<span id="cb71-21"><a href="#cb71-21" aria-hidden="true"></a><span class="dt">void</span> h(string* ptr) {</span>
-<span id="cb71-22"><a href="#cb71-22" aria-hidden="true"></a>  let z = allocate(<span class="dv">1234</span>);</span>
-<span id="cb71-23"><a href="#cb71-23" aria-hidden="true"></a>  <span class="cf">if</span> (randBool()) {</span>
-<span id="cb71-24"><a href="#cb71-24" aria-hidden="true"></a>    _free_intptr(z);</span>
-<span id="cb71-25"><a href="#cb71-25" aria-hidden="true"></a>    _free_str(ptr);</span>
-<span id="cb71-26"><a href="#cb71-26" aria-hidden="true"></a>    throw <span class="st">&quot;Halt&quot;</span>;</span>
-<span id="cb71-27"><a href="#cb71-27" aria-hidden="true"></a>  }</span>
-<span id="cb71-28"><a href="#cb71-28" aria-hidden="true"></a>  _free_intptr(z);</span>
-<span id="cb71-29"><a href="#cb71-29" aria-hidden="true"></a>  _free_str(ptr);</span>
-<span id="cb71-30"><a href="#cb71-30" aria-hidden="true"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb71"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> f<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a>  let x<span class="op">:</span> string<span class="op">*</span> <span class="op">=</span> _allocate_str<span class="op">(</span><span class="st">&quot;A fresh affine variable&quot;</span><span class="op">);</span></span>
+<span id="cb71-3"><a href="#cb71-3" aria-hidden="true" tabindex="-1"></a>  try <span class="op">{</span></span>
+<span id="cb71-4"><a href="#cb71-4" aria-hidden="true" tabindex="-1"></a>    g<span class="op">(</span>x<span class="op">);</span></span>
+<span id="cb71-5"><a href="#cb71-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> catch <span class="op">{</span></span>
+<span id="cb71-6"><a href="#cb71-6" aria-hidden="true" tabindex="-1"></a>    rethrow<span class="op">;</span></span>
+<span id="cb71-7"><a href="#cb71-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb71-8"><a href="#cb71-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb71-9"><a href="#cb71-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb71-10"><a href="#cb71-10" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> g<span class="op">(</span>string<span class="op">*</span> ptr<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb71-11"><a href="#cb71-11" aria-hidden="true" tabindex="-1"></a>  let y<span class="op">:</span> string<span class="op">*</span> <span class="op">=</span> _allocate_str<span class="op">(</span><span class="st">&quot;Another heap-allocated string&quot;</span><span class="op">);</span></span>
+<span id="cb71-12"><a href="#cb71-12" aria-hidden="true" tabindex="-1"></a>  try <span class="op">{</span></span>
+<span id="cb71-13"><a href="#cb71-13" aria-hidden="true" tabindex="-1"></a>    h<span class="op">(</span>ptr<span class="op">);</span></span>
+<span id="cb71-14"><a href="#cb71-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> catch <span class="op">{</span></span>
+<span id="cb71-15"><a href="#cb71-15" aria-hidden="true" tabindex="-1"></a>    _free_str<span class="op">(</span>y<span class="op">);</span></span>
+<span id="cb71-16"><a href="#cb71-16" aria-hidden="true" tabindex="-1"></a>    rethrow<span class="op">;</span></span>
+<span id="cb71-17"><a href="#cb71-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb71-18"><a href="#cb71-18" aria-hidden="true" tabindex="-1"></a>  _free_str<span class="op">(</span>y<span class="op">);</span></span>
+<span id="cb71-19"><a href="#cb71-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb71-20"><a href="#cb71-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb71-21"><a href="#cb71-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> h<span class="op">(</span>string<span class="op">*</span> ptr<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb71-22"><a href="#cb71-22" aria-hidden="true" tabindex="-1"></a>  let z <span class="op">=</span> allocate<span class="op">(</span><span class="dv">1234</span><span class="op">);</span></span>
+<span id="cb71-23"><a href="#cb71-23" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>randBool<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb71-24"><a href="#cb71-24" aria-hidden="true" tabindex="-1"></a>    _free_intptr<span class="op">(</span>z<span class="op">);</span></span>
+<span id="cb71-25"><a href="#cb71-25" aria-hidden="true" tabindex="-1"></a>    _free_str<span class="op">(</span>ptr<span class="op">);</span></span>
+<span id="cb71-26"><a href="#cb71-26" aria-hidden="true" tabindex="-1"></a>    throw <span class="st">&quot;Halt&quot;</span><span class="op">;</span></span>
+<span id="cb71-27"><a href="#cb71-27" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb71-28"><a href="#cb71-28" aria-hidden="true" tabindex="-1"></a>  _free_intptr<span class="op">(</span>z<span class="op">);</span></span>
+<span id="cb71-29"><a href="#cb71-29" aria-hidden="true" tabindex="-1"></a>  _free_str<span class="op">(</span>ptr<span class="op">);</span></span>
+<span id="cb71-30"><a href="#cb71-30" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h3 id="linear-types-exceptions-prior">Prior Art</h3>
-<p>Herb Sutter, <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0709r4.pdf"><em>Zero-overhead deterministic exceptions: Throwing values</em></a>:</p>
+<p>Herb Sutter, <a
+href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0709r4.pdf"><em>Zero-overhead
+deterministic exceptions: Throwing values</em></a>:</p>
 <blockquote>
-<p>An alternate result is never an “error” (it is success, so report it using return). This includes “partial suc- cess” such as that a buffer was too small for the entire request but was filled to capacity so more can be read on the next call.</p>
+<p>An alternate result is never an “error” (it is success, so report it
+using return). This includes “partial suc- cess” such as that a buffer
+was too small for the entire request but was filled to capacity so more
+can be read on the next call.</p>
 <p>[…]</p>
-<p>A programming bug or abstract machine corruption is never an “error” (both are not programmatically re- coverable, so report them to a human, by default using fail-fast). Programming bugs (e.g., out-of-bounds ac- cess, null dereference) and abstract machine corruption (e.g., stack overflow) cause a corrupted state that can- not be recovered from programmatically, and so they should never be reported to the calling code as errors that code could somehow handle.</p>
+<p>A programming bug or abstract machine corruption is never an “error”
+(both are not programmatically re- coverable, so report them to a human,
+by default using fail-fast). Programming bugs (e.g., out-of-bounds ac-
+cess, null dereference) and abstract machine corruption (e.g., stack
+overflow) cause a corrupted state that can- not be recovered from
+programmatically, and so they should never be reported to the calling
+code as errors that code could somehow handle.</p>
 </blockquote>
-<p>In the same vein, the <a href="http://joeduffyblog.com/2016/02/07/the-error-model/">Midori approach</a> to exception handling:</p>
+<p>In the same vein, the <a
+href="http://joeduffyblog.com/2016/02/07/the-error-model/">Midori
+approach</a> to exception handling:</p>
 <blockquote>
-<p>A recoverable error is usually the result of programmatic data validation. Some code has examined the state of the world and deemed the situation unacceptable for progress. Maybe it’s some markup text being parsed, user input from a website, or a transient network connection failure. In these cases, programs are expected to recover. The developer who wrote this code must think about what to do in the event of failure because it will happen in well-constructed programs no matter what you do. The response might be to communicate the situation to an end-user, retry, or abandon the operation entirely, however it is a predictable and, frequently, planned situation, despite being called an “error.”</p>
-<p>A bug is a kind of error the programmer didn’t expect. Inputs weren’t validated correctly, logic was written wrong, or any host of problems have arisen. Such problems often aren’t even detected promptly; it takes a while until “secondary effects” are observed indirectly, at which point significant damage to the program’s state might have occurred. Because the developer didn’t expect this to happen, all bets are off. All data structures reachable by this code are now suspect. And because these problems aren’t necessarily detected promptly, in fact, a whole lot more is suspect. Depending on the isolation guarantees of your language, perhaps the entire process is tainted.</p>
+<p>A recoverable error is usually the result of programmatic data
+validation. Some code has examined the state of the world and deemed the
+situation unacceptable for progress. Maybe it’s some markup text being
+parsed, user input from a website, or a transient network connection
+failure. In these cases, programs are expected to recover. The developer
+who wrote this code must think about what to do in the event of failure
+because it will happen in well-constructed programs no matter what you
+do. The response might be to communicate the situation to an end-user,
+retry, or abandon the operation entirely, however it is a predictable
+and, frequently, planned situation, despite being called an “error.”</p>
+<p>A bug is a kind of error the programmer didn’t expect. Inputs weren’t
+validated correctly, logic was written wrong, or any host of problems
+have arisen. Such problems often aren’t even detected promptly; it takes
+a while until “secondary effects” are observed indirectly, at which
+point significant damage to the program’s state might have occurred.
+Because the developer didn’t expect this to happen, all bets are off.
+All data structures reachable by this code are now suspect. And because
+these problems aren’t necessarily detected promptly, in fact, a whole
+lot more is suspect. Depending on the isolation guarantees of your
+language, perhaps the entire process is tainted.</p>
 </blockquote>
-<p>In Swift, contract violations terminate the program. In Ada, contract violations will throw an exception. In Rust, contract violations can panic. Panic can unwind or abort, depending on a compiler switch. This is a pragmatic strategy: the application developer, rather than the library developer, chooses whether to unwind or abort.</p>
-<p>In the specific case of overflow, Rust checks overflow on Debug builds, but uses two’s complement modular arithmetic semantics on Release builds for performance. This is questionable.</p>
+<p>In Swift, contract violations terminate the program. In Ada, contract
+violations will throw an exception. In Rust, contract violations can
+panic. Panic can unwind or abort, depending on a compiler switch. This
+is a pragmatic strategy: the application developer, rather than the
+library developer, chooses whether to unwind or abort.</p>
+<p>In the specific case of overflow, Rust checks overflow on Debug
+builds, but uses two’s complement modular arithmetic semantics on
+Release builds for performance. This is questionable.</p>
 <h3 id="linear-types-exceptions-conclusion">Conclusion</h3>
 <p>We started with the following error categories:</p>
 <ol type="1">
@@ -1139,53 +2305,121 @@ throw(...);</code></pre></li>
 <li><p>Memory Allocation Failure.</p></li>
 <li><p>Failure Conditions.</p></li>
 </ol>
-<p>For points #1 and #2 we can do nothing. For points #4 and #5 we use values to represent failures. This leaves point #3, for which there are four error handling strategies:</p>
+<p>For points #1 and #2 we can do nothing. For points #4 and #5 we use
+values to represent failures. This leaves point #3, for which there are
+four error handling strategies:</p>
 <ol type="1">
 <li><p>Terminate the program.</p></li>
 <li><p>Terminate the thread.</p></li>
-<li><p>Linear type system with PacLang-like capturing of the linear environment.</p></li>
+<li><p>Linear type system with PacLang-like capturing of the linear
+environment.</p></li>
 <li><p>Affine type system with stack unwinding and destructors.</p></li>
 </ol>
-<p>We reject exception handling on the grounds of semantic complexity, implementational complexity, and unsolved fundamental issues like the double throw problem (refer to the 15 point list of problems with exception handling).</p>
-<p>Without exception handling, there’s no benefit to an affine type system over a linear one. In fact, absent exception handling, affine types are strictly worse than linear types, because:</p>
+<p>We reject exception handling on the grounds of semantic complexity,
+implementational complexity, and unsolved fundamental issues like the
+double throw problem (refer to the 15 point list of problems with
+exception handling).</p>
+<p>Without exception handling, there’s no benefit to an affine type
+system over a linear one. In fact, absent exception handling, affine
+types are strictly worse than linear types, because:</p>
 <ol type="1">
 <li><p>Values can be silently forgotted by mistake.</p></li>
 <li><p>There are implicit function calls.</p></li>
-<li><p>Destruction order can change without the code changing, thus making code more unpredictable.</p></li>
+<li><p>Destruction order can change without the code changing, thus
+making code more unpredictable.</p></li>
 </ol>
-<p>The PacLang solution to integrating linear types and exceptions is essentially returning <code>Result</code> types, so it can be rejected on the grounds that it is too onerous.</p>
+<p>The PacLang solution to integrating linear types and exceptions is
+essentially returning <code>Result</code> types, so it can be rejected
+on the grounds that it is too onerous.</p>
 <p>That leaves us with two approaches:</p>
 <ol type="1">
 <li><p>On contract violation, terminate the program.</p></li>
 <li><p>On contract violation, terminate the thread.</p></li>
 </ol>
-<p>The choice between the two is essentially a choice between security and error reporting:</p>
+<p>The choice between the two is essentially a choice between security
+and error reporting:</p>
 <ol type="1">
-<li><p>If we crash the program we can be more certain we’re being secure, but testing code that uses assertions becomes much harder: if we want to ensure a function crashes on a certain input, we have to spawn a whole new process to run that function and report back.</p></li>
-<li><p>If we crash only the process, we can do better error reporting and make it cheaper to unit-test potentially crashing code. But it creates the potential for misuse: a programmer could spawn threads, have them crash, and continue running the program, accumulating leaked memory and hanging file handles. In a long-running server environment, this could lead to a DOS attack.</p></li>
+<li><p>If we crash the program we can be more certain we’re being
+secure, but testing code that uses assertions becomes much harder: if we
+want to ensure a function crashes on a certain input, we have to spawn a
+whole new process to run that function and report back.</p></li>
+<li><p>If we crash only the process, we can do better error reporting
+and make it cheaper to unit-test potentially crashing code. But it
+creates the potential for misuse: a programmer could spawn threads, have
+them crash, and continue running the program, accumulating leaked memory
+and hanging file handles. In a long-running server environment, this
+could lead to a DOS attack.</p></li>
 </ol>
-<p>By a hair, we err on the side of correctness and prefer to terminate the program to assure security. Special compiler flags might exist for unit tests that change the behaviour from crashing the program to crashing the thread, so we can unit test crashing functions more cheaply.</p>
+<p>By a hair, we err on the side of correctness and prefer to terminate
+the program to assure security. Special compiler flags might exist for
+unit tests that change the behaviour from crashing the program to
+crashing the thread, so we can unit test crashing functions more
+cheaply.</p>
 <h3 id="linear-types-exceptions-biblio">Bibliography</h3>
 <ol type="1">
-<li><p>Thrippleton, Richard, and Alan Mycroft. “Memory safety with exceptions and linear types.”</p></li>
-<li><p>Tov, Jesse A., and Riccardo Pucella. <a href="https://dl.acm.org/citation.cfm?doid=2048066.2048115">“A theory of substructural types and control.”</a> ACM SIGPLAN Notices. Vol. 46. No. 10. ACM, 2011.</p></li>
+<li><p>Thrippleton, Richard, and Alan Mycroft. “Memory safety with
+exceptions and linear types.”</p></li>
+<li><p>Tov, Jesse A., and Riccardo Pucella. <a
+href="https://dl.acm.org/citation.cfm?doid=2048066.2048115">“A theory of
+substructural types and control.”</a> ACM SIGPLAN Notices. Vol. 46.
+No. 10. ACM, 2011.</p></li>
 </ol>
 <h2 id="rationale-cap">Capability-Based Security</h2>
-<p>Seen from the surface, the Earth’s crust appears immense; seen from afar, it is the thinnest skin of silicon over a cannonball of iron many times its mass.</p>
-<p>Analogously with software: we write masses of application code, but it sits on tens of millions of lines of open source code: the library ecosystem, both direct and transitive dependencies. This is far too much code for one team to audit. Avoiding dependencies in commercial software is unrealistic: you can’t write the universe from scratch, and if you do, you will lose out to competitors closer to the efficient frontier.</p>
-<p>The problem is that code is overwhelmingly permissionless. Or, rather: all code has uniform root permissions. The size of today’s software ecosystems has introduced a new category of security vulnerability: the <a href="https://en.wikipedia.org/wiki/Supply_chain_attack">supply chain attack</a>. An attacker adds malware to an innocent library used transitively by millions. It is downloaded and run, with the user’s permissions, on the computers of hundreds of thousands of programmers, and afterwards, on application servers.</p>
-<p>The solution is <a href="https://en.wikipedia.org/wiki/Capability-based_security">capability-based security</a>. Code shoud be permissioned. To access the console, or the filesystem, or the network, libraries should require the capability to do so. Then it is evident, from function signatures, what each library is able to do, and what level of auditing is required.</p>
-<p>Furthermore: capabilities can be arbitrarily granular. Beneath the capability to access the entire filesystem, we can have a capability to access a specific directory and its contents, or just a specific file, further divided into read, write, and read-write permissions. For network access, we can have capabilities to access a specific host, or capabilities to read, write, and read-write to a socket.</p>
-<p>Access to the computer clock, too, <a href="https://twitter.com/robotlolita/status/1474351603008389122">should be restricted</a>, since accurate timing information can be used by malicious or compromised dependencies to carry out a <a href="https://en.wikipedia.org/wiki/Timing_attack">timing attack</a> or exploit a <a href="https://en.wikipedia.org/wiki/Side-channel_attack">side-channel vulnerability</a> such as <a href="https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)">Spectre</a>.</p>
+<p>Seen from the surface, the Earth’s crust appears immense; seen from
+afar, it is the thinnest skin of silicon over a cannonball of iron many
+times its mass.</p>
+<p>Analogously with software: we write masses of application code, but
+it sits on tens of millions of lines of open source code: the library
+ecosystem, both direct and transitive dependencies. This is far too much
+code for one team to audit. Avoiding dependencies in commercial software
+is unrealistic: you can’t write the universe from scratch, and if you
+do, you will lose out to competitors closer to the efficient
+frontier.</p>
+<p>The problem is that code is overwhelmingly permissionless. Or,
+rather: all code has uniform root permissions. The size of today’s
+software ecosystems has introduced a new category of security
+vulnerability: the <a
+href="https://en.wikipedia.org/wiki/Supply_chain_attack">supply chain
+attack</a>. An attacker adds malware to an innocent library used
+transitively by millions. It is downloaded and run, with the user’s
+permissions, on the computers of hundreds of thousands of programmers,
+and afterwards, on application servers.</p>
+<p>The solution is <a
+href="https://en.wikipedia.org/wiki/Capability-based_security">capability-based
+security</a>. Code shoud be permissioned. To access the console, or the
+filesystem, or the network, libraries should require the capability to
+do so. Then it is evident, from function signatures, what each library
+is able to do, and what level of auditing is required.</p>
+<p>Furthermore: capabilities can be arbitrarily granular. Beneath the
+capability to access the entire filesystem, we can have a capability to
+access a specific directory and its contents, or just a specific file,
+further divided into read, write, and read-write permissions. For
+network access, we can have capabilities to access a specific host, or
+capabilities to read, write, and read-write to a socket.</p>
+<p>Access to the computer clock, too, <a
+href="https://twitter.com/robotlolita/status/1474351603008389122">should
+be restricted</a>, since accurate timing information can be used by
+malicious or compromised dependencies to carry out a <a
+href="https://en.wikipedia.org/wiki/Timing_attack">timing attack</a> or
+exploit a <a
+href="https://en.wikipedia.org/wiki/Side-channel_attack">side-channel
+vulnerability</a> such as <a
+href="https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)">Spectre</a>.</p>
 <h3 id="linear-caps">Linear Capabilities</h3>
-<p>A capability is a value that represents an unforgeable proof of the authority to perform an action. They have the following properties:</p>
+<p>A capability is a value that represents an unforgeable proof of the
+authority to perform an action. They have the following properties:</p>
 <ol type="1">
 <li><p>Capabilities can be destroyed.</p></li>
 <li><p>Capabilities can be surrended by passing them to others.</p></li>
 <li><p>Capabilities cannot be duplicated.</p></li>
-<li><p>Capabilities cannot be acquired out of thin air: they must be passed by the client.</p></li>
+<li><p>Capabilities cannot be acquired out of thin air: they must be
+passed by the client.</p></li>
 </ol>
-<p>Capabilities in Austral are implemented as linear types: they are destroyed by being consumed, they are surrended by simply passing the value to a function, they are non-duplicable since linear types cannot be duplicated. The fourth restriction must be implemented manually by the programmer.</p>
+<p>Capabilities in Austral are implemented as linear types: they are
+destroyed by being consumed, they are surrended by simply passing the
+value to a function, they are non-duplicable since linear types cannot
+be duplicated. The fourth restriction must be implemented manually by
+the programmer.</p>
 <p>Let’s consider some examples.</p>
 <h3 id="example-file-access">Example: File Access</h3>
 <p>Consider a non-capability-secure filesystem API:</p>
@@ -1205,14 +2439,21 @@ throw(...);</code></pre></li>
     function writeFile(path: &amp;![Path, R], content: String): Unit;
 end module.</code></pre>
 <p>(Error handling etc. omitted for clarity.)</p>
-<p>Here, any client can construct a path from a string, then read the file pointed to by that path or write to it. A compromised transitive dependency could then read the contents of <code>/etc/passwd</code>, or any file in the filesystem that the process has access to, like so:</p>
+<p>Here, any client can construct a path from a string, then read the
+file pointed to by that path or write to it. A compromised transitive
+dependency could then read the contents of <code>/etc/passwd</code>, or
+any file in the filesystem that the process has access to, like so:</p>
 <pre class="austral"><code>let p: Path := makePath(&quot;/etc/passwd&quot;);
 let secrets: String := readFile(&amp;p);
 -- Send this over the network, using an
 -- equally capability-insecure network
 -- API.</code></pre>
-<p>In the context of code running on a programmer’s development computer, that means personal information. In the context of code running on an application server, that means confidential bussiness information.</p>
-<p>What does a capability-secure filesystem API look like? Like this:</p>
+<p>In the context of code running on a programmer’s development
+computer, that means personal information. In the context of code
+running on an application server, that means confidential bussiness
+information.</p>
+<p>What does a capability-secure filesystem API look like? Like
+this:</p>
 <pre class="austral"><code>module Files is
     type Path: Linear;
 
@@ -1235,18 +2476,34 @@ let secrets: String := readFile(&amp;p);
     generic [R: Region]
     function writeFile(path: &amp;![Path, R], content: String): Unit;
 end module.</code></pre>
-<p>This demonstrates the hieararchical nature of capabilities, and how granular we can go:</p>
+<p>This demonstrates the hieararchical nature of capabilities, and how
+granular we can go:</p>
 <ol type="1">
-<li><p>If you have a <code>Filesystem</code> capability, you can get the <code>Path</code> to the root directory. This is essentially read/write access to the entire filesystem.</p></li>
-<li><p>If you have a <code>Path</code> to a directory, you can get a path to a subdirectory or a file, but you can’t go <em>up</em> from a directory to its parent.</p></li>
-<li><p>If you have a <code>Path</code> to a file, you can read from it or write to it.</p></li>
+<li><p>If you have a <code>Filesystem</code> capability, you can get the
+<code>Path</code> to the root directory. This is essentially read/write
+access to the entire filesystem.</p></li>
+<li><p>If you have a <code>Path</code> to a directory, you can get a
+path to a subdirectory or a file, but you can’t go <em>up</em> from a
+directory to its parent.</p></li>
+<li><p>If you have a <code>Path</code> to a file, you can read from it
+or write to it.</p></li>
 </ol>
-<p>Each capability can only be created by providing proof of a higher-level, more powerful, broader capability.</p>
-<p>Then, if you have a logging library that takes a <code>Path</code> to the logs directory, you know it has access to that directory and to that directory only. If a library doesn’t take a <code>Filesystem</code> capability, it has no access to the filesystem.</p>
-<p>But: how do we create a <code>Filesystem</code> value? The next section explains this.</p>
+<p>Each capability can only be created by providing proof of a
+higher-level, more powerful, broader capability.</p>
+<p>Then, if you have a logging library that takes a <code>Path</code> to
+the logs directory, you know it has access to that directory and to that
+directory only. If a library doesn’t take a <code>Filesystem</code>
+capability, it has no access to the filesystem.</p>
+<p>But: how do we create a <code>Filesystem</code> value? The next
+section explains this.</p>
 <h3 id="root-cap">The Root Capability</h3>
-<p>Capabilities cannot be created out of thin air: they can only be created by proving proof that the client has access to a more powerful capability. This recursion has to end somewhere.</p>
-<p>The root of the capability hierarchy is a value of type <code>RootCapability</code>. This is the first argument to the entrypoint function of an Austral program. For our capability-secure filesystem API, we’d add a couple of functions:</p>
+<p>Capabilities cannot be created out of thin air: they can only be
+created by proving proof that the client has access to a more powerful
+capability. This recursion has to end somewhere.</p>
+<p>The root of the capability hierarchy is a value of type
+<code>RootCapability</code>. This is the first argument to the
+entrypoint function of an Austral program. For our capability-secure
+filesystem API, we’d add a couple of functions:</p>
 <pre class="austral"><code>-- Acquire the filesystem capability, when the client can
 -- provide proof that they have the root capability.
 generic [R: Region]
@@ -1290,15 +2547,31 @@ function main(root: Root_Capability): ExitCode is
     return ExitSuccess();
 end;</code></pre>
 <h3 id="capabilities-ffi-boundary">The FFI Boundary</h3>
-<p>Ultimately, all guarantees are lost at the FFI boundary. Because foreign functions are permissionless, we can implement both the capability-free and the capability-secure APIs in Austral. Does that mean these guarantees are worthless?</p>
-<p>No. To use the FFI, a module has to be marked as <a href="/spec/modules#unsafe-modules">unsafe</a> using the <code>Unsafe_Module</code> pragma.</p>
-<p>The idea is that a list of unsafe modules in all dependencies (including transitive ones) can be collected by the build system. Then, only code at the FFI boundary needs to be audited, to ensure that it correctly wraps the capability-insecure outside world under a correct, linear, capability-secure API.</p>
+<p>Ultimately, all guarantees are lost at the FFI boundary. Because
+foreign functions are permissionless, we can implement both the
+capability-free and the capability-secure APIs in Austral. Does that
+mean these guarantees are worthless?</p>
+<p>No. To use the FFI, a module has to be marked as <a
+href="/spec/modules#unsafe-modules">unsafe</a> using the
+<code>Unsafe_Module</code> pragma.</p>
+<p>The idea is that a list of unsafe modules in all dependencies
+(including transitive ones) can be collected by the build system. Then,
+only code at the FFI boundary needs to be audited, to ensure that it
+correctly wraps the capability-insecure outside world under a correct,
+linear, capability-secure API.</p>
 <h1 id="syntax">Syntax</h1>
 <p>This section describes Austral’s syntax using EBNF.</p>
-<p><em>(Note: the most up-to-date description of Austral’s syntax is the Menhir syntax definition <a href="https://github.com/austral/austral/blob/master/lib/Parser.mly">here</a>. This section is out of date.)</em></p>
+<p><em>(Note: the most up-to-date description of Austral’s syntax is the
+Menhir syntax definition <a
+href="https://github.com/austral/austral/blob/master/lib/Parser.mly">here</a>.
+This section is out of date.)</em></p>
 <h2 id="syntax-meta">Meta-Language</h2>
-<p>Quick guide: definition is <code>=</code>, definitions are terminated with with <code>;</code>. Concatenation is <code>,</code>. Alternation is <code>|</code>. Optional is <code>[...]</code>. Repetition (zero or more) is <code>{...}</code>.</p>
-<p>The syntax has two start symbols: one for interface files, and one for module body files.</p>
+<p>Quick guide: definition is <code>=</code>, definitions are terminated
+with with <code>;</code>. Concatenation is <code>,</code>. Alternation
+is <code>|</code>. Optional is <code>[...]</code>. Repetition (zero or
+more) is <code>{...}</code>.</p>
+<p>The syntax has two start symbols: one for interface files, and one
+for module body files.</p>
 <h2 id="syntax-modules">Modules</h2>
 <pre><code>module interface = [docstring], {import}, &quot;interface&quot;, module name, &quot;is&quot;
                    {interface declaration}, &quot;end.&quot;;
@@ -1356,32 +2629,51 @@ lowercase = &quot;a&quot; | &quot;b&quot; | &quot;c&quot; | &quot;d&quot; | &quo
 digit = &quot;0&quot; | &quot;1&quot; | &quot;2&quot; | &quot;3&quot; | &quot;4&quot; | &quot;5&quot; | &quot;6&quot; | &quot;7&quot; | &quot;8&quot; | &quot;9&quot;;
 symbol = &quot;$&quot; | &quot;?&quot; | &quot;&#39;&quot;</code></pre>
 <h1 id="modules">Module System</h1>
-<p>Modules are the unit of code organization in Austral. Modules have two parts: the module interface file and the module body file.</p>
+<p>Modules are the unit of code organization in Austral. Modules have
+two parts: the module interface file and the module body file.</p>
 <h2 id="module-interfaces">Module Interfaces</h2>
-<p>The interface contains declarations that are importable by other modules.</p>
+<p>The interface contains declarations that are importable by other
+modules.</p>
 <p>A module interface can have the following declarations:</p>
 <ul>
-<li><a href="/spec/declarations#opaque-constant">Opaque constant declarations</a></li>
-<li><a href="/spec/declarations#record-definition">Record definitions</a></li>
-<li><a href="/spec/declarations#union-definition">Union definitions</a></li>
-<li><a href="/spec/declarations#function-declaration">Function declarations</a></li>
-<li><a href="/spec/declarations#typeclass-definition">Typeclass definitions</a></li>
-<li><a href="/spec/declarations#instance-declaration">Instance declarations</a></li>
+<li><a href="/spec/declarations#opaque-constant">Opaque constant
+declarations</a></li>
+<li><a href="/spec/declarations#record-definition">Record
+definitions</a></li>
+<li><a href="/spec/declarations#union-definition">Union
+definitions</a></li>
+<li><a href="/spec/declarations#function-declaration">Function
+declarations</a></li>
+<li><a href="/spec/declarations#typeclass-definition">Typeclass
+definitions</a></li>
+<li><a href="/spec/declarations#instance-declaration">Instance
+declarations</a></li>
 </ul>
 <h2 id="module-bodies">Module Bodies</h2>
-<p>The module body contains private declarations (that are not importable by other modules), as well as declarations that provide the definitions of opaque declarations in the module interface.</p>
+<p>The module body contains private declarations (that are not
+importable by other modules), as well as declarations that provide the
+definitions of opaque declarations in the module interface.</p>
 <p>A module body can have the following kinds of declarations:</p>
 <ul>
-<li><a href="/spec/declarations#constant-definition">Constant definitions</a></li>
-<li><a href="/spec/declarations#record-definition">Record definitions</a></li>
-<li><a href="/spec/declarations#union-definition">Union definitions</a></li>
-<li><a href="/spec/declarations#function-definition">Function definitions</a></li>
-<li><a href="/spec/declarations#typeclass-definition">Typeclass definitions</a></li>
-<li><a href="/spec/declarations#instance-definitions">Instance definitions</a></li>
+<li><a href="/spec/declarations#constant-definition">Constant
+definitions</a></li>
+<li><a href="/spec/declarations#record-definition">Record
+definitions</a></li>
+<li><a href="/spec/declarations#union-definition">Union
+definitions</a></li>
+<li><a href="/spec/declarations#function-definition">Function
+definitions</a></li>
+<li><a href="/spec/declarations#typeclass-definition">Typeclass
+definitions</a></li>
+<li><a href="/spec/declarations#instance-definitions">Instance
+definitions</a></li>
 </ul>
 <h2 id="module-imports">Imports</h2>
-<p>Imports are the mechanism through which declarations from other modules are brought into an Austral module.</p>
-<p>Imports appear at the top of both the module interface and module body files, before the <code>module</code> or <code>module body</code> keywords.</p>
+<p>Imports are the mechanism through which declarations from other
+modules are brought into an Austral module.</p>
+<p>Imports appear at the top of both the module interface and module
+body files, before the <code>module</code> or <code>module body</code>
+keywords.</p>
 <p>An import statement has the general form:</p>
 <p><span class="math display">\[
 \text{import} ~ m ~ (
@@ -1392,16 +2684,25 @@ symbol = &quot;$&quot; | &quot;?&quot; | &quot;&#39;&quot;</code></pre>
 \]</span></p>
 <p>Where:</p>
 <ol type="1">
-<li><span class="math inline">\(m\)</span> is the name of the module to import the declarations from.</li>
+<li><span class="math inline">\(m\)</span> is the name of the module to
+import the declarations from.</li>
 <li><span class="math inline">\(p\)</span> is one of:
 <ol type="1">
-<li>The name of a declaration in <span class="math inline">\(m\)</span>.</li>
-<li>The name of a union case in a public union in <span class="math inline">\(m\)</span>.</li>
-<li>The name of a method in a public typeclass in <span class="math inline">\(m\)</span>.</li>
+<li>The name of a declaration in <span
+class="math inline">\(m\)</span>.</li>
+<li>The name of a union case in a public union in <span
+class="math inline">\(m\)</span>.</li>
+<li>The name of a method in a public typeclass in <span
+class="math inline">\(m\)</span>.</li>
 </ol></li>
-<li><span class="math inline">\(l\)</span> is the <em>local nickname</em> of <span class="math inline">\(p\)</span>: that is, appearances of <span class="math inline">\(l\)</span> in the file where this import statement appears will be interpreted as though they were references to <span class="math inline">\(p\)</span>.</li>
+<li><span class="math inline">\(l\)</span> is the <em>local
+nickname</em> of <span class="math inline">\(p\)</span>: that is,
+appearances of <span class="math inline">\(l\)</span> in the file where
+this import statement appears will be interpreted as though they were
+references to <span class="math inline">\(p\)</span>.</li>
 </ol>
-<p>Note that import nicknames are not mandatory, and without them, the statement looks like:</p>
+<p>Note that import nicknames are not mandatory, and without them, the
+statement looks like:</p>
 <p><span class="math display">\[
 \text{import} ~ m ~ (
 \text{p}_1,
@@ -1409,28 +2710,40 @@ symbol = &quot;$&quot; | &quot;?&quot; | &quot;&#39;&quot;</code></pre>
 \text{p}_n
 );
 \]</span></p>
-<p>If an identifier <span class="math inline">\(p\)</span> is imported without a nickname, references to <span class="math inline">\(p\)</span> in the source text will be interpreted as references to that foreign declaration, union case, or method.</p>
+<p>If an identifier <span class="math inline">\(p\)</span> is imported
+without a nickname, references to <span class="math inline">\(p\)</span>
+in the source text will be interpreted as references to that foreign
+declaration, union case, or method.</p>
 <h2 id="import-nicknames">Import Nicknames</h2>
 <p>Import nicknames serve a dual purpose:</p>
 <ol type="1">
-<li><p>If two modules <span class="math inline">\(A\)</span> and <span class="math inline">\(B\)</span> define a declaration with the same name <span class="math inline">\(p\)</span>, we can import both of them by assigning one or both of them a nickname, like:</p>
+<li><p>If two modules <span class="math inline">\(A\)</span> and <span
+class="math inline">\(B\)</span> define a declaration with the same name
+<span class="math inline">\(p\)</span>, we can import both of them by
+assigning one or both of them a nickname, like:</p>
 <p><span class="math display">\[
 \begin{aligned}
 ~\text{import} ~ A ~ (\text{p} ~ \text{as} ~ \text{a});\\
 ~\text{import} ~ B ~ (\text{p} ~ \text{as} ~ \text{b});
 \end{aligned}
 \]</span></p></li>
-<li><p>They allow us to use shorter names for longer identifiers where necessary.</p></li>
+<li><p>They allow us to use shorter names for longer identifiers where
+necessary.</p></li>
 </ol>
 <h2 id="instance-imports">Instance Imports</h2>
-<p>When importing from a module <span class="math inline">\(M\)</span>, all public typeclass instances in <span class="math inline">\(M\)</span> are imported automatically.</p>
+<p>When importing from a module <span class="math inline">\(M\)</span>,
+all public typeclass instances in <span class="math inline">\(M\)</span>
+are imported automatically.</p>
 <h2 id="unsafe-modules">Unsafe Modules</h2>
-<p>An <strong>unsafe module</strong> is a module that can access FFI features. Specifically, an unsafe module can:</p>
+<p>An <strong>unsafe module</strong> is a module that can access FFI
+features. Specifically, an unsafe module can:</p>
 <ul>
-<li>Import declarations from the <code>Austral.Memory</code> module.</li>
+<li>Import declarations from the <code>Austral.Memory</code>
+module.</li>
 <li>Use the <code>External_Name</code> pragma.</li>
 </ul>
-<p>To specify that a module is unsafe, the <code>Unsafe_Module</code> pragma must be used in the module body. For example:</p>
+<p>To specify that a module is unsafe, the <code>Unsafe_Module</code>
+pragma must be used in the module body. For example:</p>
 <pre class="austral"><code>module body Example is
     pragma Unsafe_Module;
 
@@ -1468,7 +2781,8 @@ end module body.</code></pre>
     -- Instances are simply declared.
     instance Class(Int32);
 end.</code></pre>
-<p>The following is a module definition that satisfies the interface:</p>
+<p>The following is a module definition that satisfies the
+interface:</p>
 <pre class="austral"><code>module Example is
     constant c : Float32 := 3.14;
 
@@ -1500,72 +2814,131 @@ end.</code></pre>
 <h1 id="types">Type System</h1>
 <p>This section describes Austral’s type system.</p>
 <h2 id="type-universes">Type Universes</h2>
-<p>Every concrete type belongs to a <em>universe</em>, which can be considered as the type of a type.</p>
+<p>Every concrete type belongs to a <em>universe</em>, which can be
+considered as the type of a type.</p>
 <p>There are two universes:</p>
 <ol type="1">
-<li>The universe of unrestricted types, denoted <code>Free</code>. Bindings with a type in the <code>Free</code> universe can be used any number of times.</li>
-<li>The universe of linear types, denoted <code>Linear</code>. These are explained in the next section.</li>
+<li>The universe of unrestricted types, denoted <code>Free</code>.
+Bindings with a type in the <code>Free</code> universe can be used any
+number of times.</li>
+<li>The universe of linear types, denoted <code>Linear</code>. These are
+explained in the next section.</li>
 </ol>
 <h2 id="linear-types">Linear Types</h2>
 <p>A type <span class="math inline">\(\tau\)</span> is linear if:</p>
 <ol type="1">
-<li><p>It contains another linear type. These types are called <em>structurally linear</em>.</p></li>
-<li><p>Is it declared to be a linear type (see “Declaring Types”). These types are called <em>declared linear</em>.</p></li>
+<li><p>It contains another linear type. These types are called
+<em>structurally linear</em>.</p></li>
+<li><p>Is it declared to be a linear type (see “Declaring Types”). These
+types are called <em>declared linear</em>.</p></li>
 </ol>
-<p>To formalize the notion of “containment” in point 1.: a type <span class="math inline">\(\tau\)</span> is said to contain a linear type <span class="math inline">\(\upsilon\)</span> (or, equivalently, a type parameter <span class="math inline">\(\upsilon\)</span> of kinds <code>Linear</code> or <code>Type</code>) if:</p>
+<p>To formalize the notion of “containment” in point 1.: a type <span
+class="math inline">\(\tau\)</span> is said to contain a linear type
+<span class="math inline">\(\upsilon\)</span> (or, equivalently, a type
+parameter <span class="math inline">\(\upsilon\)</span> of kinds
+<code>Linear</code> or <code>Type</code>) if:</p>
 <ol start="3" type="1">
-<li><span class="math inline">\(\tau\)</span> is a record, where at least one field contains <span class="math inline">\(\upsilon\)</span>.</li>
-<li><span class="math inline">\(\tau\)</span> is a union, where at least one case contains a field that contains <span class="math inline">\(\upsilon\)</span>.</li>
+<li><span class="math inline">\(\tau\)</span> is a record, where at
+least one field contains <span
+class="math inline">\(\upsilon\)</span>.</li>
+<li><span class="math inline">\(\tau\)</span> is a union, where at least
+one case contains a field that contains <span
+class="math inline">\(\upsilon\)</span>.</li>
 </ol>
 <h2 id="type-parameters">Type Parameters</h2>
 <p>A <em>type parameter</em> has the form:</p>
 <p><span class="math display">\[
 \text{p}: K
 \]</span></p>
-<p>where <span class="math inline">\(\text{p}\)</span> is an identifier and <span class="math inline">\(K\)</span> is a <em>kind</em>. The set of permitted kinds is:</p>
+<p>where <span class="math inline">\(\text{p}\)</span> is an identifier
+and <span class="math inline">\(K\)</span> is a <em>kind</em>. The set
+of permitted kinds is:</p>
 <ul>
-<li><p><code>Free</code>: a type parameter with kind <code>Free</code> accepts types that belong to the <code>Free</code> universe.</p></li>
-<li><p><code>Linear</code>: a type parameter with kind <code>Linear</code> accepts types that belong to the <code>Linear</code> universe.</p></li>
-<li><p><code>Type</code>: a type parameter with kind <code>Type</code> accepts any kind of type. Values with this type are treated as though they were <code>Linear</code> (i.e., they can only be used once, they can’t be silently dropped, etc.) since this is the lowest common denomination of behaviour.</p></li>
-<li><p><code>Region</code>: a type parameter with kind <code>Region</code> accepts regions.</p></li>
+<li><p><code>Free</code>: a type parameter with kind <code>Free</code>
+accepts types that belong to the <code>Free</code> universe.</p></li>
+<li><p><code>Linear</code>: a type parameter with kind
+<code>Linear</code> accepts types that belong to the <code>Linear</code>
+universe.</p></li>
+<li><p><code>Type</code>: a type parameter with kind <code>Type</code>
+accepts any kind of type. Values with this type are treated as though
+they were <code>Linear</code> (i.e., they can only be used once, they
+can’t be silently dropped, etc.) since this is the lowest common
+denomination of behaviour.</p></li>
+<li><p><code>Region</code>: a type parameter with kind
+<code>Region</code> accepts regions.</p></li>
 </ul>
 <h2 id="type-parameter-constraints">Type Parameter Constraints</h2>
-<p>Type parameters are “universally quantified”, meaning we can’t use any behaviour specific to the type. All we can do with an unknown type <code>T</code> is stuff it in a data structure or move it around. If we want to compare two instances of <code>T</code> for equality, for example, we’d have to pass a function pointer to a comparison function.</p>
-<p>Type parameter constraints solve this, by allowing us to constrain a type parameter to only accept types that implement a set of typeclasses.</p>
-<p>Let <span class="math inline">\(\text{p}\)</span> be a type parameter name, <span class="math inline">\(\text{U}\)</span> be one of <span class="math inline">\(\{Free, Linear, Type\}\)</span>, and <span class="math inline">\(\{C_1, ..., C_n\}\)</span> be a set of type class names. Then:</p>
+<p>Type parameters are “universally quantified”, meaning we can’t use
+any behaviour specific to the type. All we can do with an unknown type
+<code>T</code> is stuff it in a data structure or move it around. If we
+want to compare two instances of <code>T</code> for equality, for
+example, we’d have to pass a function pointer to a comparison
+function.</p>
+<p>Type parameter constraints solve this, by allowing us to constrain a
+type parameter to only accept types that implement a set of
+typeclasses.</p>
+<p>Let <span class="math inline">\(\text{p}\)</span> be a type parameter
+name, <span class="math inline">\(\text{U}\)</span> be one of <span
+class="math inline">\(\{Free, Linear, Type\}\)</span>, and <span
+class="math inline">\(\{C_1, ..., C_n\}\)</span> be a set of type class
+names. Then:</p>
 <p><span class="math display">\[
 \text{p}: U(C_1, ..., C_n)
 \]</span></p>
-<p>Denotes a type parameter constrained to only accept types that implement every listed class.</p>
+<p>Denotes a type parameter constrained to only accept types that
+implement every listed class.</p>
 <p>For example:</p>
 <pre><code>generic [T: Free(Printable, TotalEquality)]
 function ...</code></pre>
 <h2 id="declaring-types">Declaring Types</h2>
-<p>When declaring a type, we must state which universe it belongs to. This is so that the programmer is aware of type universes, and these are not relegated to just an implementation detail of the memory management scheme.</p>
+<p>When declaring a type, we must state which universe it belongs to.
+This is so that the programmer is aware of type universes, and these are
+not relegated to just an implementation detail of the memory management
+scheme.</p>
 <p>The rules around declaring types are:</p>
 <ol type="1">
-<li>A type that is not structurally linear can be declared to be <code>Linear</code>, and will be treated as an <code>Linear</code> type.</li>
-<li>A type that is structurally linear <em>cannot</em> be declared as belonging to the <code>Free</code> universe.</li>
+<li>A type that is not structurally linear can be declared to be
+<code>Linear</code>, and will be treated as an <code>Linear</code>
+type.</li>
+<li>A type that is structurally linear <em>cannot</em> be declared as
+belonging to the <code>Free</code> universe.</li>
 </ol>
-<p>In the case of generic types, we often want to postpone the decision of which universe the type belongs to. For example:</p>
+<p>In the case of generic types, we often want to postpone the decision
+of which universe the type belongs to. For example:</p>
 <pre class="austral"><code>record Singleton[T: Type]: ??? is
     value: T
 end;</code></pre>
-<p>Here, the type parameter <code>T</code> can accept types in both the <code>Free</code> and <code>Linear</code> universes. If we had to declare a universe for <code>Singleton</code>, the only way to make this type-check would be to declare that <code>Singleton</code> is in the <code>Linear</code> universe, since that is the lowest common denominator.</p>
+<p>Here, the type parameter <code>T</code> can accept types in both the
+<code>Free</code> and <code>Linear</code> universes. If we had to
+declare a universe for <code>Singleton</code>, the only way to make this
+type-check would be to declare that <code>Singleton</code> is in the
+<code>Linear</code> universe, since that is the lowest common
+denominator.</p>
 <p>However, Austral lets us do this:</p>
 <pre class="austral"><code>record Singleton[T: Type]: Type is
     value: T
 end;</code></pre>
-<p>When <code>Type</code> appears as the declared universe of a type, it is not a universe, but rather, it tells the compiler to choose the universe when a concrete type is instantiated, using the algorithm described in “Automatic Universe Classification”. So <code>Singleton[Int32]</code> would be in the <code>Free</code> universe, but <code>Singleton[U]</code> (where <code>U : Linear</code>) belongs to the <code>Linear</code> universe.</p>
+<p>When <code>Type</code> appears as the declared universe of a type, it
+is not a universe, but rather, it tells the compiler to choose the
+universe when a concrete type is instantiated, using the algorithm
+described in “Automatic Universe Classification”. So
+<code>Singleton[Int32]</code> would be in the <code>Free</code>
+universe, but <code>Singleton[U]</code> (where <code>U : Linear</code>)
+belongs to the <code>Linear</code> universe.</p>
 <h2 id="built-in-types">Built-In Types</h2>
-<p>The following types are built into austral and available to all code.</p>
+<p>The following types are built into austral and available to all
+code.</p>
 <h3 id="unit">Unit</h3>
 <pre class="austral"><code>type Unit: Free;</code></pre>
-<p><code>Unit</code> is the type of functions that return no useful value. The only value of type <code>Unit</code> is the constant <code>nil</code>.</p>
+<p><code>Unit</code> is the type of functions that return no useful
+value. The only value of type <code>Unit</code> is the constant
+<code>nil</code>.</p>
 <h3 id="boolean">Boolean</h3>
 <pre class="austral"><code>type Bool: Free;</code></pre>
-<p><code>Bool</code> is the type of logical and comparison operators.</p>
-<p>The only <code>Bool</code> values are the constants <code>true</code> and <code>false</code>.</p>
+<p><code>Bool</code> is the type of logical and comparison
+operators.</p>
+<p>The only <code>Bool</code> values are the constants <code>true</code>
+and <code>false</code>.</p>
 <h3 id="integers">Integer Types</h3>
 <p>The following integer types are available:</p>
 <table>
@@ -1629,28 +3002,43 @@ end;</code></pre>
 <h3 id="floats">Floating Point Types</h3>
 <pre class="austral"><code>type Float32: Free;
 type Float64: Free;</code></pre>
-<p>The two floating-point types are <code>Float32</code> and <code>Float64</code>.</p>
+<p>The two floating-point types are <code>Float32</code> and
+<code>Float64</code>.</p>
 <h3 id="read-ref">Read-Only Reference</h3>
 <pre class="austral"><code>type Reference[T: Linear, R: Region]: Free;</code></pre>
-<p>The type <code>Reference</code> is the type of read-only references to linear values. Values of this type are bound to a region and are acquired by borrowing.</p>
-<p>Syntactic sugar is available: <code>&amp;[T, R]</code> expands to <code>Reference[T, R]</code>.</p>
+<p>The type <code>Reference</code> is the type of read-only references
+to linear values. Values of this type are bound to a region and are
+acquired by borrowing.</p>
+<p>Syntactic sugar is available: <code>&amp;[T, R]</code> expands to
+<code>Reference[T, R]</code>.</p>
 <h3 id="write-ref">Read-Write Reference</h3>
 <pre class="austral"><code>type WriteReference[T: Linear, R: Region]: Free;</code></pre>
-<p>The type <code>WriteReference</code> is the type of read-write references to linear values. Values of this type are bound to a region and are acquired by borrowing.</p>
-<p>Syntactic sugar is available: <code>&amp;![T, R]</code> expands to <code>WriteReference[T, R]</code>.</p>
+<p>The type <code>WriteReference</code> is the type of read-write
+references to linear values. Values of this type are bound to a region
+and are acquired by borrowing.</p>
+<p>Syntactic sugar is available: <code>&amp;![T, R]</code> expands to
+<code>WriteReference[T, R]</code>.</p>
 <h3 id="root-capability">Root Capability</h3>
 <pre class="austral"><code>type RootCapability: Linear;</code></pre>
-<p>The type <code>RootCapability</code> is the root of the capability hierarchy. It is the type of the first parameter to the entrypoint function.</p>
+<p>The type <code>RootCapability</code> is the root of the capability
+hierarchy. It is the type of the first parameter to the entrypoint
+function.</p>
 <h3 id="fixed-array">Fixed-Size Arrays</h3>
 <pre class="austral"><code>type FixedArray[T: Free]: Free;</code></pre>
-<p><code>FixedArray</code> is the type of arrays whose size is fixed, but not necessarily known at compile time. The type of string literals is <code>FixedArray[Nat8]</code>.</p>
+<p><code>FixedArray</code> is the type of arrays whose size is fixed,
+but not necessarily known at compile time. The type of string literals
+is <code>FixedArray[Nat8]</code>.</p>
 <h3 id="func-pointer">Function Pointer Types</h3>
 <pre class="austral"><code>type Fn[A_0: Type, ..., A_n: Type, R: Type]: Free</code></pre>
-<p><code>Fn</code> is the type of function pointers. It is always free.</p>
+<p><code>Fn</code> is the type of function pointers. It is always
+free.</p>
 <h1 id="type-classes">Type Classes</h1>
-<p>Type classes, borrowed from Haskell 98, give us a bounded and sensible form of ad-hoc polymorphism.</p>
+<p>Type classes, borrowed from Haskell 98, give us a bounded and
+sensible form of ad-hoc polymorphism.</p>
 <h2 id="type-class-uniqueness">Instance Uniqueness</h2>
-<p>In Austral, instances have to be globally unique: you can’t have multiple instances of the same typeclass for the same type, or for overlapping type parameters. So, the following are prohibited:</p>
+<p>In Austral, instances have to be globally unique: you can’t have
+multiple instances of the same typeclass for the same type, or for
+overlapping type parameters. So, the following are prohibited:</p>
 <pre class="austral"><code>instance TC(Nat32);
 instance TC(Nat32);</code></pre>
 <p>But also these:</p>
@@ -1659,7 +3047,8 @@ instance TC(Pointer[T]);
 
 generic [T: Linear]
 instance TC(Pointer[T]);</code></pre>
-<p>Enforcing uniqueness, however, does not require loading the entire program in memory. It only requires enforcing these three rules:</p>
+<p>Enforcing uniqueness, however, does not require loading the entire
+program in memory. It only requires enforcing these three rules:</p>
 <ol type="1">
 <li><p>Within a module, no instances overlap.</p></li>
 <li><p>You are only allowed to define instances for:</p>
@@ -1668,10 +3057,12 @@ instance TC(Pointer[T]);</code></pre>
 <li><p>Local typeclasses and foreign types.</p></li>
 <li><p>Foreign typeclasses and local types.</p></li>
 </ol>
-<p>But you are <em>not</em> allowed to define an instance for a foreign typeclass and a foreign type.</p></li>
+<p>But you are <em>not</em> allowed to define an instance for a foreign
+typeclass and a foreign type.</p></li>
 </ol>
 <h2 id="instance-resolution">Instance Resolution</h2>
-<p>This section describes how an instance is resolved from a method call.</p>
+<p>This section describes how an instance is resolved from a method
+call.</p>
 <p>Consider a typeclass:</p>
 <pre class="austral"><code>typeclass Printable(T: Free) is
     method Print(t: T): Unit;
@@ -1681,18 +3072,37 @@ end;</code></pre>
 instance Printable(Bool);
 generic [U: Type]
 instance Printable(Pointer[U]);</code></pre>
-<p>Then, given a call like <code>Print(true)</code>, we know <code>Print</code> is a method in the typeclass <code>Printable</code>. Then, we match the parameter list <code>(t: T)</code> to the argument list <code>(true)</code> and get a set of type parameter bindings <code>{ T =&gt; true }</code>. The set will be the singleton set because typeclass definitions can only have one type parameter.</p>
-<p>In this case, <code>true</code> is called the <em>dispatch type</em>.</p>
-<p>Then we iterate over all the visible instances of the type class <code>Printable</code> (i.e.: those that are defined in or imported into the current module), and find the instance where the instance argument matches the dispatch type.</p>
-<p>In the case of a concrete instance that’s just comparing the types for equality, and we’ll find the instance of <code>Printable</code> for <code>Boolean</code>.</p>
-<p>Consider a call like <code>Print(ptr)</code> where <code>ptr</code> has type <code>Pointer[Nat8]</code>. Then, we repeat the process, except we’ll find a generic instance of <code>Printable</code>. Matching <code>Pointer[U]</code> to <code>Pointer[Nat8]</code> produces the bindings set <code>{ U =&gt; Nat8 }</code>.</p>
+<p>Then, given a call like <code>Print(true)</code>, we know
+<code>Print</code> is a method in the typeclass <code>Printable</code>.
+Then, we match the parameter list <code>(t: T)</code> to the argument
+list <code>(true)</code> and get a set of type parameter bindings
+<code>{ T =&gt; true }</code>. The set will be the singleton set because
+typeclass definitions can only have one type parameter.</p>
+<p>In this case, <code>true</code> is called the <em>dispatch
+type</em>.</p>
+<p>Then we iterate over all the visible instances of the type class
+<code>Printable</code> (i.e.: those that are defined in or imported into
+the current module), and find the instance where the instance argument
+matches the dispatch type.</p>
+<p>In the case of a concrete instance that’s just comparing the types
+for equality, and we’ll find the instance of <code>Printable</code> for
+<code>Boolean</code>.</p>
+<p>Consider a call like <code>Print(ptr)</code> where <code>ptr</code>
+has type <code>Pointer[Nat8]</code>. Then, we repeat the process, except
+we’ll find a generic instance of <code>Printable</code>. Matching
+<code>Pointer[U]</code> to <code>Pointer[Nat8]</code> produces the
+bindings set <code>{ U =&gt; Nat8 }</code>.</p>
 <h1 id="decl">Declarations</h1>
-<p>This section describes the kind of declarations that can appear in Austral modules.</p>
+<p>This section describes the kind of declarations that can appear in
+Austral modules.</p>
 <h2 id="opaque-constant">Opaque Constant</h2>
-<p>If <code>c</code> is an identifier, <code>T</code> is a type specifier, then:</p>
+<p>If <code>c</code> is an identifier, <code>T</code> is a type
+specifier, then:</p>
 <pre class="austral"><code>constant c : T;</code></pre>
 <p>is an opaque constant declaration.</p>
-<p>These can only appear in the module interface file, and must be accompanied by a matching constant declaration in the module body file.</p>
+<p>These can only appear in the module interface file, and must be
+accompanied by a matching constant declaration in the module body
+file.</p>
 <p>Example:</p>
 <pre class="austral"><code>module Example is
     -- Defines a public constant `Pi`, which can be imported
@@ -1706,11 +3116,16 @@ module body Example is
     constant pi : Float64 := 3.14;
 end module body.</code></pre>
 <h2 id="constant-definition">Constant Definition</h2>
-<p>If <code>c</code> is an identifier, <code>T</code> is a type specifier, and <code>E</code> is a constant expression of type <code>T</code>, then:</p>
+<p>If <code>c</code> is an identifier, <code>T</code> is a type
+specifier, and <code>E</code> is a constant expression of type
+<code>T</code>, then:</p>
 <pre class="austral"><code>constant c : T := V;</code></pre>
-<p>Defines a constant named <code>C</code> of type <code>T</code> with a value of <code>V</code>.</p>
+<p>Defines a constant named <code>C</code> of type <code>T</code> with a
+value of <code>V</code>.</p>
 <p>Constant definitions can only appear in the module body file.</p>
-<p>If the module interface file has a corresponding opaque constant declaration, then the constant is public and can be imported by other modules. Otherwise, it is private.</p>
+<p>If the module interface file has a corresponding opaque constant
+declaration, then the constant is public and can be imported by other
+modules. Otherwise, it is private.</p>
 <p>Example:</p>
 <pre class="austral"><code>module body Example is
     -- If there is no corresponding opaque constant declaration
@@ -1719,8 +3134,12 @@ end module body.</code></pre>
     constant Pi : DoubleFloat := 3.14;
 end module body.</code></pre>
 <h2 id="record-definition">Record Definition</h2>
-<p>A record is an unordered collection of values, called fields, which are addressed by name.</p>
-<p>If <span class="math inline">\(R\)</span> is an identifier, <span class="math inline">\(\{R_0, ..., R_n\}\)</span> is a set of identifiers, and <span class="math inline">\(\{T_0, ..., T_n\}\)</span> is a set of type specifiers, then:</p>
+<p>A record is an unordered collection of values, called fields, which
+are addressed by name.</p>
+<p>If <span class="math inline">\(R\)</span> is an identifier, <span
+class="math inline">\(\{R_0, ..., R_n\}\)</span> is a set of
+identifiers, and <span class="math inline">\(\{T_0, ..., T_n\}\)</span>
+is a set of type specifiers, then:</p>
 <pre class="austral"><code>record R is
   R_0 : T_0;
   R_1 : T_1;
@@ -1728,10 +3147,14 @@ end module body.</code></pre>
   R_n : T_n;
 end</code></pre>
 <p>Defines the record <code>R</code>.</p>
-<p>Unlike C, records in Austral are unordered, and the compiler is free to choose how the records will be ordered and laid out in memory. The compiler must select a single layout for every instance of a given record type.</p>
+<p>Unlike C, records in Austral are unordered, and the compiler is free
+to choose how the records will be ordered and laid out in memory. The
+compiler must select a single layout for every instance of a given
+record type.</p>
 <dl>
 <dt>Examples</dt>
-<dd><p>Given the record:</p>
+<dd>
+<p>Given the record:</p>
 <pre class="austral"><code>record Vector3 is
     x : Float32;
     y : Float32;
@@ -1747,7 +3170,8 @@ let V2 : Vector3 := Vector3(
 </dd>
 </dl>
 <h2 id="union-definition">Union Definition</h2>
-<p>Unions are like datatypes in ML and Haskell. They have constructors and, optionally, constructors have values associated to them.</p>
+<p>Unions are like datatypes in ML and Haskell. They have constructors
+and, optionally, constructors have values associated to them.</p>
 <p>When a constructor has associated values, it’s either:</p>
 <ol type="1">
 <li>A single unnamed value.</li>
@@ -1773,7 +3197,10 @@ let C2 : Color := RGB(
 );
 let C3 : Color := Greyscale(50);</code></pre>
 <h2 id="function-declaration">Function Declaration</h2>
-<p>Let <span class="math inline">\(\text{f}\)</span> be an identifier, <span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n: \tau_n\}\)</span> be a set of value parameters, and <span class="math inline">\(\tau_r\)</span> be a type. Then:</p>
+<p>Let <span class="math inline">\(\text{f}\)</span> be an identifier,
+<span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n:
+\tau_n\}\)</span> be a set of value parameters, and <span
+class="math inline">\(\tau_r\)</span> be a type. Then:</p>
 <p><span class="math display">\[
 \text{function} ~ \text{f} (
 \text{p}_1: \tau_1,
@@ -1782,8 +3209,12 @@ let C3 : Color := Greyscale(50);</code></pre>
 ): \tau_r
 ;
 \]</span></p>
-<p>declares a <em>concrete function</em> <span class="math inline">\(\text{f}\)</span> with the given value parameter set and return type <span class="math inline">\(\tau_r\)</span>.</p>
-<p>More generally, given a set of type parameter <span class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n: k_n\}\)</span>, then:</p>
+<p>declares a <em>concrete function</em> <span
+class="math inline">\(\text{f}\)</span> with the given value parameter
+set and return type <span class="math inline">\(\tau_r\)</span>.</p>
+<p>More generally, given a set of type parameter <span
+class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n:
+k_n\}\)</span>, then:</p>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{generic} ~
@@ -1798,19 +3229,29 @@ let C3 : Color := Greyscale(50);</code></pre>
 ;
 \end{aligned}
 \]</span></p>
-<p>declares a <em>generic function</em> <span class="math inline">\(\text{f}\)</span> with the given type parameter set, value parameter set, and return type <span class="math inline">\(\tau_r\)</span>.</p>
-<p>There must be a corresponding function definition in the module body file that has the same signature.</p>
-<p>Function declarations can only appear in the module interface file.</p>
+<p>declares a <em>generic function</em> <span
+class="math inline">\(\text{f}\)</span> with the given type parameter
+set, value parameter set, and return type <span
+class="math inline">\(\tau_r\)</span>.</p>
+<p>There must be a corresponding function definition in the module body
+file that has the same signature.</p>
+<p>Function declarations can only appear in the module interface
+file.</p>
 <p>Examples:</p>
 <ol type="1">
-<li><p>The following declares the identity function, a generic function with a single type parameter and a single value parameter:</p>
+<li><p>The following declares the identity function, a generic function
+with a single type parameter and a single value parameter:</p>
 <pre class="austral"><code>generic (t : Type)
 function Identity(x: T): T is
     return x;
 end</code></pre></li>
 </ol>
 <h2 id="function-definition">Function Definition</h2>
-<p>Let <span class="math inline">\(\text{f}\)</span> be an identifier, <span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n: \tau_n\}\)</span> be a set of value parameters, <span class="math inline">\(\tau_r\)</span> be a type, and <span class="math inline">\(s\)</span> be a statement. Then:</p>
+<p>Let <span class="math inline">\(\text{f}\)</span> be an identifier,
+<span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n:
+\tau_n\}\)</span> be a set of value parameters, <span
+class="math inline">\(\tau_r\)</span> be a type, and <span
+class="math inline">\(s\)</span> be a statement. Then:</p>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{function} ~ \text{f} (
@@ -1823,8 +3264,13 @@ end</code></pre></li>
 &amp; \text{end} ;
 \end{aligned}
 \]</span></p>
-<p>defines a <em>concrete function</em> <span class="math inline">\(\text{f}\)</span> with the given value parameter set, return type <span class="math inline">\(\tau_r\)</span>, and body <span class="math inline">\(s\)</span>.</p>
-<p>More generally, given a set of type parameter <span class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n: k_n\}\)</span>, then:</p>
+<p>defines a <em>concrete function</em> <span
+class="math inline">\(\text{f}\)</span> with the given value parameter
+set, return type <span class="math inline">\(\tau_r\)</span>, and body
+<span class="math inline">\(s\)</span>.</p>
+<p>More generally, given a set of type parameter <span
+class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n:
+k_n\}\)</span>, then:</p>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{generic} ~
@@ -1841,11 +3287,17 @@ end</code></pre></li>
 &amp; \text{end} ;
 \end{aligned}
 \]</span></p>
-<p>defines a <em>generic function</em> <span class="math inline">\(\text{f}\)</span> with the given type parameter set, value parameter set, return type <span class="math inline">\(\tau_r\)</span>, and body <span class="math inline">\(s\)</span>.</p>
-<p>If there is a corresponding function declaration in the module interface file, the function is public, otherwise it is private.</p>
+<p>defines a <em>generic function</em> <span
+class="math inline">\(\text{f}\)</span> with the given type parameter
+set, value parameter set, return type <span
+class="math inline">\(\tau_r\)</span>, and body <span
+class="math inline">\(s\)</span>.</p>
+<p>If there is a corresponding function declaration in the module
+interface file, the function is public, otherwise it is private.</p>
 <p>Examples:</p>
 <ol type="1">
-<li><p>This defines a recursive function to compute the Fibonacci sequence:</p>
+<li><p>This defines a recursive function to compute the Fibonacci
+sequence:</p>
 <pre class="austral"><code>function fib(n: Nat64): Nat64 is
     if n &lt;= 2 then
         return n;
@@ -1857,15 +3309,18 @@ end</code></pre></li>
 <h2 id="typeclass-definition">Typeclass Definition</h2>
 <p>Given:</p>
 <ol type="1">
-<li><p>Identifiers <span class="math inline">\(\text{t}\)</span> and <span class="math inline">\(\text{p}\)</span>.</p></li>
+<li><p>Identifiers <span class="math inline">\(\text{t}\)</span> and
+<span class="math inline">\(\text{p}\)</span>.</p></li>
 <li><p>A universe <span class="math inline">\(u\)</span>.</p></li>
 <li><p>A set of method signatures:</p>
 <p><span class="math display">\[
 \left\{
 \begin{aligned}
-&amp; \text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1,\\
+&amp; \text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}:
+\tau\_{1n} ): \tau\_1,\\
 &amp; \dots,\\
-&amp; \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m
+&amp; \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}:
+\tau\_{mn} ): \tau\_m
 \end{aligned}
 \right\}
 \]</span></p></li>
@@ -1874,41 +3329,61 @@ end</code></pre></li>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{typeclass} ~ \text{t} ( \text{p} : u ) ~ \text{is} \\
-&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11},
+\dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ; \\
 &amp; ~~~~ \dots; \\
-&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1},
+\dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ; \\
 &amp; \text{end} ;
 \end{aligned}
 \]</span></p>
-<p>Defines a typeclass <span class="math inline">\(\text{t}\)</span> with a parameter <span class="math inline">\(\text{p}\)</span> which accepts types in the universe <span class="math inline">\(u\)</span>, and has methods <span class="math inline">\(\{\text{m}_1, ..., \text{m}_m\}\)</span>.</p>
-<p>A typeclass declaration can appear in the module interface file (in which case it is public) or in the module body file (in which case it is private).</p>
+<p>Defines a typeclass <span class="math inline">\(\text{t}\)</span>
+with a parameter <span class="math inline">\(\text{p}\)</span> which
+accepts types in the universe <span class="math inline">\(u\)</span>,
+and has methods <span class="math inline">\(\{\text{m}_1, ...,
+\text{m}_m\}\)</span>.</p>
+<p>A typeclass declaration can appear in the module interface file (in
+which case it is public) or in the module body file (in which case it is
+private).</p>
 <p>Examples:</p>
 <ol type="1">
-<li><p>Defines a typeclass <code>Printable</code> for types in the <code>Type</code> universe, with a method <code>Print</code>:</p>
+<li><p>Defines a typeclass <code>Printable</code> for types in the
+<code>Type</code> universe, with a method <code>Print</code>:</p>
 <pre class="austral"><code>typeclass Printable(T : Type) is
     method Print(value: T): Unit;
 end</code></pre></li>
 </ol>
 <h2 id="instance-declaration">Instance Declaration</h2>
-<p>Let <span class="math inline">\(\text{t}\)</span> be the name of a typeclass and <span class="math inline">\(\tau\)</span> be a type specifier. Then:</p>
+<p>Let <span class="math inline">\(\text{t}\)</span> be the name of a
+typeclass and <span class="math inline">\(\tau\)</span> be a type
+specifier. Then:</p>
 <p><span class="math display">\[
 \text{instance} ~ \text{t} ( \\tau ) ;
 \]</span></p>
-<p>declares an instance of the typeclass <span class="math inline">\(\text{t}\)</span> for the type <span class="math inline">\(\tau\)</span>.</p>
-<p>Instance declaration can only appear in the module interface file, and must have a matching instance definition in the module body file.</p>
+<p>declares an instance of the typeclass <span
+class="math inline">\(\text{t}\)</span> for the type <span
+class="math inline">\(\tau\)</span>.</p>
+<p>Instance declaration can only appear in the module interface file,
+and must have a matching instance definition in the module body
+file.</p>
 <p>An instance declaration means the instance is public.</p>
 <h2 id="instance-definition">Instance Definition</h2>
 <p>Given:</p>
 <ol type="1">
-<li><p>An identifier <span class="math inline">\(\text{t}\)</span> that names name of a typeclass with universe <span class="math inline">\(u\)</span>.</p></li>
-<li><p>A type specifier <span class="math inline">\(\tau\)</span> in the universe <span class="math inline">\(u\)</span>.</p></li>
+<li><p>An identifier <span class="math inline">\(\text{t}\)</span> that
+names name of a typeclass with universe <span
+class="math inline">\(u\)</span>.</p></li>
+<li><p>A type specifier <span class="math inline">\(\tau\)</span> in the
+universe <span class="math inline">\(u\)</span>.</p></li>
 <li><p>A set of method definitions:</p>
 <p><span class="math display">\[
 \left\{
 \begin{aligned}
-&amp;\text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ~ \text{is} ~ s_1,\\
+&amp;\text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}:
+\tau\_{1n} ): \tau\_1 ~ \text{is} ~ s_1,\\
 &amp;\dots,\\
-&amp;\text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ~ \text{is} ~ s_m
+&amp;\text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}:
+\tau\_{mn} ): \tau\_m ~ \text{is} ~ s_m
 \end{aligned}
 \right\}
 \]</span></p></li>
@@ -1917,18 +3392,23 @@ end</code></pre></li>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{instance} ~ \text{t} ( \tau ) ~ \text{is} \\
-&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ~ \text{is} ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11},
+\dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ~ \text{is} ; \\
 &amp; ~~~~~~~~ s_1 ; \\
 &amp; ~~~~ \text{end} ; \\
 &amp; ~~~~ \dots; \\
-&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ~ \text{is} ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1},
+\dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ~ \text{is} ; \\
 &amp; ~~~~~~~~ s_m ; \\
 &amp; ~~~~ \text{end} ; \\
 &amp; \text{end} ;
 \end{aligned}
 \]</span></p>
-<p>defines a <em>concrete instance</em> of the typeclass <span class="math inline">\(\text{t}\)</span>.</p>
-<p>More generally, given a set of type parameters <span class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n: k_n\}\)</span>, then:</p>
+<p>defines a <em>concrete instance</em> of the typeclass <span
+class="math inline">\(\text{t}\)</span>.</p>
+<p>More generally, given a set of type parameters <span
+class="math inline">\(\{\text{tp}_1: k_1, \dots, \text{tp}_n:
+k_n\}\)</span>, then:</p>
 <p><span class="math display">\[
 \begin{aligned}
 &amp; \text{generic} ~
@@ -1936,17 +3416,20 @@ end</code></pre></li>
 \text{tp}_1: k_1, \dots, \text{tp}_n: k_n
 ] \\
 &amp; \text{instance} ~ \text{t} ( \tau ) ~ \text{is} \\
-&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11}, \dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ~ \text{is} ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_1 ( \text{p}\_{11}: \tau\_{11},
+\dots, \text{p}\_{1n}: \tau\_{1n} ): \tau\_1 ~ \text{is} ; \\
 &amp; ~~~~~~~~ s_1 ; \\
 &amp; ~~~~ \text{end} ; \\
 &amp; ~~~~ \dots; \\
-&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1}, \dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ~ \text{is} ; \\
+&amp; ~~~~ \text{method} ~ \text{m}\_m ( \text{p}\_{m1}: \tau\_{m1},
+\dots, \text{p}\_{mn}: \tau\_{mn} ): \tau\_m ~ \text{is} ; \\
 &amp; ~~~~~~~~ s_m ; \\
 &amp; ~~~~ \text{end} ; \\
 &amp; \text{end} ;
 \end{aligned}
 \]</span></p>
-<p>defines a <em>generic instance</em> of the typeclass <span class="math inline">\(\text{t}\)</span>.</p>
+<p>defines a <em>generic instance</em> of the typeclass <span
+class="math inline">\(\text{t}\)</span>.</p>
 <p>Examples:</p>
 <pre class="austral"><code>typeclass Printable(T : Type) is
     method Print(value: T): Unit;
@@ -1964,23 +3447,41 @@ end</code></pre>
 <p>Example:</p>
 <pre class="austral"><code>skip;</code></pre>
 <h2 id="stmt-let">Let Statement</h2>
-<p>If <code>N</code> is an identifier, <code>T</code> is a type specifier, and <code>E</code> is an expression of type <code>T</code>, then:</p>
+<p>If <code>N</code> is an identifier, <code>T</code> is a type
+specifier, and <code>E</code> is an expression of type <code>T</code>,
+then:</p>
 <pre class="austral"><code>let N: T := e;</code></pre>
-<p>is a <code>let</code> statement which defines a variable with name <code>N</code>, type <code>T</code>, and initial value <code>E</code>.</p>
-<p>A <code>let</code> statement is one of the few places where type information flows forward: the declared type is used to disambiguate the type of the expression when the expression is, for example, a call to a return-type polymorphic function.</p>
+<p>is a <code>let</code> statement which defines a variable with name
+<code>N</code>, type <code>T</code>, and initial value
+<code>E</code>.</p>
+<p>A <code>let</code> statement is one of the few places where type
+information flows forward: the declared type is used to disambiguate the
+type of the expression when the expression is, for example, a call to a
+return-type polymorphic function.</p>
 <h2 id="stmt-let-destructure">Let Destructure Statement</h2>
-<p>A let destructure statement is used to break apart records, creating a binding for each field in the record.</p>
-<p>The utility of this is: when you have a linear record type, you can’t extract the value of a linear field from it, because it consumes the record as a whole, and leaves unconsumed any other linear fields in the record. So the record must be broken up into its constituent values, and then optionally reassembled.</p>
-<p>If <code>R</code> is an expression of type <code>T</code>, and <code>T</code> is a record type with field set <code>{R_1: T_1, ..., R_n: T_n}</code>, then:</p>
+<p>A let destructure statement is used to break apart records, creating
+a binding for each field in the record.</p>
+<p>The utility of this is: when you have a linear record type, you can’t
+extract the value of a linear field from it, because it consumes the
+record as a whole, and leaves unconsumed any other linear fields in the
+record. So the record must be broken up into its constituent values, and
+then optionally reassembled.</p>
+<p>If <code>R</code> is an expression of type <code>T</code>, and
+<code>T</code> is a record type with field set
+<code>{R_1: T_1, ..., R_n: T_n}</code>, then:</p>
 <pre class="austral"><code>let {R_1: T_1, ..., R_n: T_n} := R;</code></pre>
 <p>is a let destructure statement.</p>
 <h2 id="stmt-assign">Assignment Statement</h2>
-<p>If <code>P</code> is an lvalue of type <code>T</code> and <code>E</code> is an expression of type <code>T</code>, then:</p>
+<p>If <code>P</code> is an lvalue of type <code>T</code> and
+<code>E</code> is an expression of type <code>T</code>, then:</p>
 <pre class="austral"><code>P := E;</code></pre>
-<p>is an assignment statement that stores the value of <code>E</code> in the location denoted by <code>P</code>.</p>
+<p>is an assignment statement that stores the value of <code>E</code> in
+the location denoted by <code>P</code>.</p>
 <p>[TODO: describe the semantics of lvalues]</p>
 <h2 id="stmt-if">If Statement</h2>
-<p>If <code>{e_1, ..., e_n}</code> is a set of expression of boolean type, and <code>{b_1, ..., b_n, b_else}</code> is a set of statements, then:</p>
+<p>If <code>{e_1, ..., e_n}</code> is a set of expression of boolean
+type, and <code>{b_1, ..., b_n, b_else}</code> is a set of statements,
+then:</p>
 <pre class="austral"><code>if e_1 then
     b_1;
 else if e_2 then
@@ -1996,13 +3497,15 @@ end if;</code></pre>
 <pre class="austral"><code>if test() then
     doSomething();
 end if;</code></pre>
-<p>An example <code>if</code> statement with a <code>true</code> branch and a <code>false</code> branch:</p>
+<p>An example <code>if</code> statement with a <code>true</code> branch
+and a <code>false</code> branch:</p>
 <pre class="austral"><code>if test() then
     doSomething();
 else
     doSomethingElse();
 end if;</code></pre>
-<p>An example <code>if</code> statement with three conditions and an else branch:</p>
+<p>An example <code>if</code> statement with three conditions and an
+else branch:</p>
 <pre class="austral"><code>if a() then
     doA();
 else if b() then
@@ -2012,14 +3515,18 @@ else if c() then
 else
     doElse();
 end if;</code></pre>
-<p>An example <code>if</code> statement with two conditions and no else branch:</p>
+<p>An example <code>if</code> statement with two conditions and no else
+branch:</p>
 <pre class="austral"><code>if a() then
     doA();
 else if b() then
     doB();
 end if;</code></pre>
 <h2 id="stmt-case">Case Statement</h2>
-<p>If <code>E</code> is an expression of a union type with cases <code>{C_1, ..., C_n}</code> and each case has slots <code>C_i = {S_i1: T_i1, ..., S_in T_im}</code>, and <code>{B_1, ..., B_n}</code> is a set of statements, then:</p>
+<p>If <code>E</code> is an expression of a union type with cases
+<code>{C_1, ..., C_n}</code> and each case has slots
+<code>C_i = {S_i1: T_i1, ..., S_in T_im}</code>, and
+<code>{B_1, ..., B_n}</code> is a set of statements, then:</p>
 <pre class="austral"><code>case E of
     when C_1(S_11: T_11, S_12: T_12, ..., S_1m: T_1m) do
         B_1;
@@ -2028,8 +3535,13 @@ end if;</code></pre>
         B_n;
 end case;</code></pre>
 <p>is a <code>case</code> statement.</p>
-<p>Case statements are used to break apart unions. For each case in a union, there must be a corresponding <code>when</code> clause in the <code>case</code> statement. Analogously: for each slot in a union case, the corresponding <code>when</code> clause must have a binding for that slot.</p>
-<p>An example of using the <code>case</code> statement on a union whose cases have no slots:</p>
+<p>Case statements are used to break apart unions. For each case in a
+union, there must be a corresponding <code>when</code> clause in the
+<code>case</code> statement. Analogously: for each slot in a union case,
+the corresponding <code>when</code> clause must have a binding for that
+slot.</p>
+<p>An example of using the <code>case</code> statement on a union whose
+cases have no slots:</p>
 <pre class="austral"><code>union Color: Free is
     case Red;
     case Green;
@@ -2063,48 +3575,63 @@ case e of
 end case;</code></pre>
 <p>An exam</p>
 <h2 id="stmt-while">While Loop</h2>
-<p>If <code>e</code> is an expression of type <code>Bool</code> and <code>b</code> is a statement, then:</p>
+<p>If <code>e</code> is an expression of type <code>Bool</code> and
+<code>b</code> is a statement, then:</p>
 <pre class="austral"><code>while e do
     b;
 end while;</code></pre>
-<p>is a while loop that iterates as long as <code>e</code> evaluates to <code>true</code>.</p>
+<p>is a while loop that iterates as long as <code>e</code> evaluates to
+<code>true</code>.</p>
 <p>Examples:</p>
 <pre class="austral"><code>-- An infinite loop
 while true do
     doForever();
 end while;</code></pre>
 <h2 id="stmt-for">For Loop</h2>
-<p>If <code>i</code> is an identifier, <code>s</code> is an expression of type <code>Nat64</code>, <code>f</code> is an expression of type <code>Nat64</code>, and <code>b</code> is a statement, and <code>s &lt;= f</code>, then:</p>
+<p>If <code>i</code> is an identifier, <code>s</code> is an expression
+of type <code>Nat64</code>, <code>f</code> is an expression of type
+<code>Nat64</code>, and <code>b</code> is a statement, and
+<code>s &lt;= f</code>, then:</p>
 <pre class="austral"><code>for i from s to f do
     b;
 end for;</code></pre>
-<p>is a for loop where <code>b</code> is executed once for each value of <code>i</code> in the interval <code>[s, f]</code>.</p>
+<p>is a for loop where <code>b</code> is executed once for each value of
+<code>i</code> in the interval <code>[s, f]</code>.</p>
 <p>Examples:</p>
 <pre class="austral"><code>for i from 0 to n do
     doSomething(i);
 end for;</code></pre>
 <h2 id="stmt-borrow">Borrow Statement</h2>
-<p>If <code>X</code> is a variable of a linear type <code>T</code>, <code>X'</code> is an identifier, <code>R</code> is an identifier, and <code>B</code> is a statement, then:</p>
+<p>If <code>X</code> is a variable of a linear type <code>T</code>,
+<code>X'</code> is an identifier, <code>R</code> is an identifier, and
+<code>B</code> is a statement, then:</p>
 <pre class="austral"><code>borrow X as X&#39; in R do
   B;
 end;</code></pre>
-<p>Is a borrow statement that borrows the variable <code>X</code> as a reference <code>X'</code> with type <code>&amp;[T, R]</code> in a new region named <code>R</code>.</p>
-<p>The variable <code>X'</code> is usable only in <code>B</code>, dually, the variable <code>X</code> cannot be used in <code>B</code>, i.e. while it is borrowed.</p>
+<p>Is a borrow statement that borrows the variable <code>X</code> as a
+reference <code>X'</code> with type <code>&amp;[T, R]</code> in a new
+region named <code>R</code>.</p>
+<p>The variable <code>X'</code> is usable only in <code>B</code>,
+dually, the variable <code>X</code> cannot be used in <code>B</code>,
+i.e. while it is borrowed.</p>
 <p>The mutable form of the borrow statement is:</p>
 <pre class="austral"><code>borrow X as X&#39; in R do
   B;
 end;</code></pre>
-<p>The only difference is that the type of <code>X'</code> is <code>&amp;![R, T]</code>.</p>
+<p>The only difference is that the type of <code>X'</code> is
+<code>&amp;![R, T]</code>.</p>
 <h2 id="stmt-discard">Discarding Statement</h2>
 <p>If <code>e</code> is an expression, then:</p>
 <pre class="austral"><code>e;</code></pre>
 <p>Evaluates that expression and discards its value.</p>
-<p>Note that discarding statements are illegal where <code>e</code> is of a linear type.</p>
+<p>Note that discarding statements are illegal where <code>e</code> is
+of a linear type.</p>
 <h2 id="stmt-return">Return Statement</h2>
 <p>If <code>e</code> is an expression, then:</p>
 <pre class="austral"><code>return e;</code></pre>
 <p>Returns from the function with the value <code>e</code>.</p>
-<p>Note that <code>return</code> statements are illegal where there are unconsumed linear values.</p>
+<p>Note that <code>return</code> statements are illegal where there are
+unconsumed linear values.</p>
 <h1 id="expr">Expressions</h1>
 <p>This section describes the semantics of Austral expressions.</p>
 <h2 id="expr-nil">Nil Constant</h2>
@@ -2112,17 +3639,26 @@ end;</code></pre>
 <pre class="austral"><code>nil</code></pre>
 <p>has type <code>Unit</code>.</p>
 <h2 id="expr-bool">Boolean Constant</h2>
-<p>The Boolean constants are the identifiers <code>true</code> and <code>false</code>.</p>
+<p>The Boolean constants are the identifiers <code>true</code> and
+<code>false</code>.</p>
 <h2 id="expr-int">Integer Constant</h2>
-<p>Integer constants have type <code>Int32</code> by default, but to improve programmer ergonomics, the compiler will try to find a type for an integer constant that makes the surrounding context work. E.g., if <code>x</code> is of type <code>Nat8</code>, then an expression like <code>x + 3</code> will work, and the <code>3</code> will be interpreted to have type <code>Nat8</code>.</p>
+<p>Integer constants have type <code>Int32</code> by default, but to
+improve programmer ergonomics, the compiler will try to find a type for
+an integer constant that makes the surrounding context work. E.g., if
+<code>x</code> is of type <code>Nat8</code>, then an expression like
+<code>x + 3</code> will work, and the <code>3</code> will be interpreted
+to have type <code>Nat8</code>.</p>
 <h2 id="expr-float">Float Constant</h2>
 <p>Floating-point number constants have type <code>Float64</code>.</p>
 <h2 id="expr-str">String Constant</h2>
 <p>String constants have type <code>FixedArray[Nat8]</code>.</p>
 <h2 id="expr-var">Variable Expression</h2>
-<p>An identifier that’s not the nil or boolean constants is a local variable or global constant, whose type is determined from the lexical environment.</p>
+<p>An identifier that’s not the nil or boolean constants is a local
+variable or global constant, whose type is determined from the lexical
+environment.</p>
 <h2 id="expr-arith">Arithmetic Expression</h2>
-<p>If <code>a</code> and <code>b</code> are two expressions of the same integer or floating point type <code>N</code>, then:</p>
+<p>If <code>a</code> and <code>b</code> are two expressions of the same
+integer or floating point type <code>N</code>, then:</p>
 <pre class="austral"><code>a+b
 a-b
 a*b
@@ -2130,11 +3666,19 @@ a/b</code></pre>
 <p>are all expressions of type <code>N</code>.</p>
 <p>In the case of division, two rules apply:</p>
 <ul>
-<li>If <code>b</code> is zero: the program aborts due to a division-by-zero error.</li>
-<li>If <code>N</code> is a signed integer type, and <code>a</code> is the minimum value that fits in that integer type, and <code>b</code> is -1: the program aborts due to a signed integer overflow error.</li>
+<li>If <code>b</code> is zero: the program aborts due to a
+division-by-zero error.</li>
+<li>If <code>N</code> is a signed integer type, and <code>a</code> is
+the minimum value that fits in that integer type, and <code>b</code> is
+-1: the program aborts due to a signed integer overflow error.</li>
 </ul>
 <h2 id="expr-funcall">Function Call</h2>
-<p>If <span class="math inline">\(\text{f}\)</span> is the name of a function with parameters <span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n: \tau_n\}\)</span> and return type <span class="math inline">\(\tau_r\)</span>, and we have a set of expressions <span class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>, then:</p>
+<p>If <span class="math inline">\(\text{f}\)</span> is the name of a
+function with parameters <span class="math inline">\(\{\text{p}_1:
+\tau_1, \dots, \text{p}_n: \tau_n\}\)</span> and return type <span
+class="math inline">\(\tau_r\)</span>, and we have a set of expressions
+<span class="math inline">\(\{e_1: \tau_1, \dots, e_n:
+\tau_n\}\)</span>, then:</p>
 <p><span class="math display">\[
 \text{f}(e_1, \dots, e_n)
 \]</span></p>
@@ -2142,9 +3686,18 @@ a/b</code></pre>
 <p><span class="math display">\[
 \text{f}(\text{p}_1 \Rightarrow e_1, \dots, \text{p}_n \Rightarrow e_n)
 \]</span></p>
-<p>are identical function call expression whose type is <span class="math inline">\(\tau_r\)</span>.</p>
+<p>are identical function call expression whose type is <span
+class="math inline">\(\tau_r\)</span>.</p>
 <h2 id="expr-methcall">Method Call</h2>
-<p>Let <span class="math inline">\(\text{m}\)</span> be the name of a method in a typeclass <span class="math inline">\(\text{t}\)</span>. After <a href="/spec/type-classes#instance-resolution">instance resolution</a> the method has parameters <span class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n: \tau_n\}\)</span> and return type <span class="math inline">\(\tau_r\)</span>. Given a set of expressions <span class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>, then:</p>
+<p>Let <span class="math inline">\(\text{m}\)</span> be the name of a
+method in a typeclass <span class="math inline">\(\text{t}\)</span>.
+After <a href="/spec/type-classes#instance-resolution">instance
+resolution</a> the method has parameters <span
+class="math inline">\(\{\text{p}_1: \tau_1, \dots, \text{p}_n:
+\tau_n\}\)</span> and return type <span
+class="math inline">\(\tau_r\)</span>. Given a set of expressions <span
+class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>,
+then:</p>
 <p><span class="math display">\[
 \text{m}(e_1, \dots, e_n)
 \]</span></p>
@@ -2152,20 +3705,38 @@ a/b</code></pre>
 <p><span class="math display">\[
 \text{m}(\text{p}_1 \Rightarrow e_1, \dots, \text{p}_n \Rightarrow e_n)
 \]</span></p>
-<p>are identical method call expression whose type is <span class="math inline">\(\tau_r\)</span>.</p>
+<p>are identical method call expression whose type is <span
+class="math inline">\(\tau_r\)</span>.</p>
 <h2 id="expr-rec-cons">Record Constructor</h2>
-<p>If <span class="math inline">\(\text{r}\)</span> is the name of a record type with slots <span class="math inline">\(\{\text{s}_1: \tau_1, \dots, \text{s}_n: \tau_n\}\)</span>, and we have a set of expressions <span class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>, then:</p>
+<p>If <span class="math inline">\(\text{r}\)</span> is the name of a
+record type with slots <span class="math inline">\(\{\text{s}_1: \tau_1,
+\dots, \text{s}_n: \tau_n\}\)</span>, and we have a set of expressions
+<span class="math inline">\(\{e_1: \tau_1, \dots, e_n:
+\tau_n\}\)</span>, then:</p>
 <p><span class="math display">\[
 \text{r}(\text{s}_1 \Rightarrow e_1, \dots, \text{s}_n \Rightarrow e_n)
 \]</span></p>
-<p>is a record constructor expression which evaluates to an instance of <span class="math inline">\(\text{r}\)</span> containing the given values.</p>
+<p>is a record constructor expression which evaluates to an instance of
+<span class="math inline">\(\text{r}\)</span> containing the given
+values.</p>
 <h2 id="expr-union-cons">Union Constructor</h2>
-<p>Let <span class="math inline">\(\text{u}\)</span> be a union type, with a case named <span class="math inline">\(\text{c}\)</span> with slots <span class="math inline">\(\{\text{s}_1: \tau_1, \dots, \text{s}_n: \tau_n\}\)</span>, and we have a set of expressions <span class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>, then:</p>
+<p>Let <span class="math inline">\(\text{u}\)</span> be a union type,
+with a case named <span class="math inline">\(\text{c}\)</span> with
+slots <span class="math inline">\(\{\text{s}_1: \tau_1, \dots,
+\text{s}_n: \tau_n\}\)</span>, and we have a set of expressions <span
+class="math inline">\(\{e_1: \tau_1, \dots, e_n: \tau_n\}\)</span>,
+then:</p>
 <p><span class="math display">\[
 \text{c}(\text{s}_1 \Rightarrow e_1, \dots, \text{s}_n \Rightarrow e_n)
 \]</span></p>
-<p>is a union constructor expression which evaluates to an instance of <span class="math inline">\(\text{u}\)</span> with case <span class="math inline">\(\text{c}\)</span> and the given values.</p>
-<p>As a shorthand, if the slot set has a single value, <span class="math inline">\(\{\text{s}: \tau\}\)</span>, and the set of expressions also has a single value <span class="math inline">\(\{e\}\)</span>, then a simplified form is possible:</p>
+<p>is a union constructor expression which evaluates to an instance of
+<span class="math inline">\(\text{u}\)</span> with case <span
+class="math inline">\(\text{c}\)</span> and the given values.</p>
+<p>As a shorthand, if the slot set has a single value, <span
+class="math inline">\(\{\text{s}: \tau\}\)</span>, and the set of
+expressions also has a single value <span
+class="math inline">\(\{e\}\)</span>, then a simplified form is
+possible:</p>
 <p><span class="math display">\[
 \text{c}(\text{s})
 \]</span></p>
@@ -2176,25 +3747,49 @@ a/b</code></pre>
 <h2 id="expr-case">Cast Expression</h2>
 <p>The cast expression has four uses:</p>
 <ol type="1">
-<li><p>Clarifying the type of integer and floating point constants.</p></li>
-<li><p>Converting between different integer and floating point types (otherwise, you get a combinatorial explosion of typeclasses).</p></li>
+<li><p>Clarifying the type of integer and floating point
+constants.</p></li>
+<li><p>Converting between different integer and floating point types
+(otherwise, you get a combinatorial explosion of typeclasses).</p></li>
 <li><p>Converting write references to read references.</p></li>
-<li><p>Clarifying the type of return type polymorphic functions.</p></li>
+<li><p>Clarifying the type of return type polymorphic
+functions.</p></li>
 </ol>
-<p>If <span class="math inline">\(e\)</span> is an expression and <span class="math inline">\(\tau\)</span> is a type, then:</p>
+<p>If <span class="math inline">\(e\)</span> is an expression and <span
+class="math inline">\(\tau\)</span> is a type, then:</p>
 <p><span class="math display">\[
 e : \tau
 \]</span></p>
-<p>is the expression that tries to cast <span class="math inline">\(e\)</span> to <span class="math inline">\(\tau\)</span>, and it evaluates to a value of type <span class="math inline">\(\tau\)</span>.</p>
+<p>is the expression that tries to cast <span
+class="math inline">\(e\)</span> to <span
+class="math inline">\(\tau\)</span>, and it evaluates to a value of type
+<span class="math inline">\(\tau\)</span>.</p>
 <p>Semantics:</p>
 <ol type="1">
-<li><p>If <span class="math inline">\(e\)</span> is an integer constant that fits in <span class="math inline">\(\tau\)</span> (e.g.: <span class="math inline">\(e\)</span> can’t be a negative integer constant if <span class="math inline">\(\tau\)</span> is <code>Nat8</code>) then <span class="math inline">\(e : \tau\)</span> is valid.</p></li>
-<li><p>If <span class="math inline">\(e\)</span> is an integer or floating point type, and <span class="math inline">\(\tau\)</span> is an integer or floating point type, then <span class="math inline">\(e : \tau\)</span> is valid.</p></li>
-<li><p>If <span class="math inline">\(e: \&amp;![T, R]\)</span> and <span class="math inline">\(\tau\)</span> is <span class="math inline">\(\&amp;[T, R]\)</span>, then <span class="math inline">\(e: \tau\)</span> is valid and downgrades the write reference to a read reference.</p></li>
-<li><p>If <span class="math inline">\(e\)</span> is a call to a return type-polymorphic function or method, and <span class="math inline">\(\tau\)</span> can clarify the return type of <span class="math inline">\(e\)</span>, then <span class="math inline">\(e : \tau\)</span> is a valid expression.</p></li>
+<li><p>If <span class="math inline">\(e\)</span> is an integer constant
+that fits in <span class="math inline">\(\tau\)</span> (e.g.: <span
+class="math inline">\(e\)</span> can’t be a negative integer constant if
+<span class="math inline">\(\tau\)</span> is <code>Nat8</code>) then
+<span class="math inline">\(e : \tau\)</span> is valid.</p></li>
+<li><p>If <span class="math inline">\(e\)</span> is an integer or
+floating point type, and <span class="math inline">\(\tau\)</span> is an
+integer or floating point type, then <span class="math inline">\(e :
+\tau\)</span> is valid.</p></li>
+<li><p>If <span class="math inline">\(e: \&amp;![T, R]\)</span> and
+<span class="math inline">\(\tau\)</span> is <span
+class="math inline">\(\&amp;[T, R]\)</span>, then <span
+class="math inline">\(e: \tau\)</span> is valid and downgrades the write
+reference to a read reference.</p></li>
+<li><p>If <span class="math inline">\(e\)</span> is a call to a return
+type-polymorphic function or method, and <span
+class="math inline">\(\tau\)</span> can clarify the return type of <span
+class="math inline">\(e\)</span>, then <span class="math inline">\(e :
+\tau\)</span> is a valid expression.</p></li>
 </ol>
 <h2 id="expr-comp">Comparison Expression</h2>
-<p>If <span class="math inline">\(a\)</span> and <span class="math inline">\(b\)</span> are both expressions of Boolean type, then:</p>
+<p>If <span class="math inline">\(a\)</span> and <span
+class="math inline">\(b\)</span> are both expressions of Boolean type,
+then:</p>
 <p><span class="math display">\[
 \begin{aligned}
 a &amp;=    b \\
@@ -2207,83 +3802,136 @@ a &amp;\geq b
 \]</span></p>
 <p>are comparison expressions with type <code>Bool</code>.</p>
 <h2 id="expr-conj">Conjunction Expression</h2>
-<p>If <code>a</code> and <code>b</code> are Boolean-typed expressions, then <code>a and b</code> is the short-circuiting and operator and evaluates to a Boolean value.</p>
+<p>If <code>a</code> and <code>b</code> are Boolean-typed expressions,
+then <code>a and b</code> is the short-circuiting and operator and
+evaluates to a Boolean value.</p>
 <h2 id="expr-disj">Disjunction Expression</h2>
-<p>If <code>a</code> and <code>b</code> are Boolean-typed expressions, then <code>a or b</code> is the short-circuiting or operator, and evaluates to a Boolean value.</p>
+<p>If <code>a</code> and <code>b</code> are Boolean-typed expressions,
+then <code>a or b</code> is the short-circuiting or operator, and
+evaluates to a Boolean value.</p>
 <h2 id="negation-expression">Negation Expression</h2>
-<p>If <code>e</code> is a Boolean-typed expression, then <code>not e</code> evaluates to the negation of the value of <code>e</code>, a Boolean value.</p>
+<p>If <code>e</code> is a Boolean-typed expression, then
+<code>not e</code> evaluates to the negation of the value of
+<code>e</code>, a Boolean value.</p>
 <h2 id="expr-if">If Expression</h2>
-<p>If <code>c</code> is a Boolean-typed expression, and <code>t</code> and <code>f</code> are expressions of the same type <code>T</code>, then:</p>
+<p>If <code>c</code> is a Boolean-typed expression, and <code>t</code>
+and <code>f</code> are expressions of the same type <code>T</code>,
+then:</p>
 <pre class="austral"><code>if c then t else f</code></pre>
-<p>is an <code>if</code> expression. <code>c</code> is evaluated first, if is <code>true</code>, <code>t</code> is evaluated and its value is returned. Otherwise, <code>f</code> is evaluated and its value is returend. The result has type <code>T</code>.</p>
+<p>is an <code>if</code> expression. <code>c</code> is evaluated first,
+if is <code>true</code>, <code>t</code> is evaluated and its value is
+returned. Otherwise, <code>f</code> is evaluated and its value is
+returend. The result has type <code>T</code>.</p>
 <h2 id="expr-path">Path Expression</h2>
-<p>The syntax of a path is: an expression called the <em>head</em> followed by a non-empty list of <em>path elements</em>, each of which is one of:</p>
+<p>The syntax of a path is: an expression called the <em>head</em>
+followed by a non-empty list of <em>path elements</em>, each of which is
+one of:</p>
 <ol type="1">
-<li>A <em>slot accessor</em> of the form <code>.s</code> where <code>s</code> is the name of a record slot.</li>
-<li>A <em>pointer slot accessor</em> of the form <code>-&gt;s</code> where <code>s</code> is the name of a record slot.</li>
-<li>An <em>array indexing element</em> of the form <code>[i]</code> where <code>i</code> is a value of type <code>Index</code>.</li>
+<li>A <em>slot accessor</em> of the form <code>.s</code> where
+<code>s</code> is the name of a record slot.</li>
+<li>A <em>pointer slot accessor</em> of the form <code>-&gt;s</code>
+where <code>s</code> is the name of a record slot.</li>
+<li>An <em>array indexing element</em> of the form <code>[i]</code>
+where <code>i</code> is a value of type <code>Index</code>.</li>
 </ol>
 <p>Path expressions are used for:</p>
 <ol type="1">
 <li><p>Accessing the contents of slots and arrays.</p></li>
-<li><p>Transforming references to records and arrays into references to their contents.</p></li>
+<li><p>Transforming references to records and arrays into references to
+their contents.</p></li>
 </ol>
 <p>Semantics:</p>
 <ol type="1">
-<li><p>All paths must end in a path in the <code>Free</code> universe. That is, if <code>x[23]-&gt;y.z</code> is a linear type, the compiler will complain.</p></li>
-<li><p>A path that starts in a reference is a reference. For example, if <code>x</code> is of type <code>&amp;[T, R]</code>, then the path <code>x-&gt;y-&gt;z</code> (assuming <code>z</code> is a record slot with type <code>U</code>) is of type <code>&amp;[U, R]</code>.</p></li>
+<li><p>All paths must end in a path in the <code>Free</code> universe.
+That is, if <code>x[23]-&gt;y.z</code> is a linear type, the compiler
+will complain.</p></li>
+<li><p>A path that starts in a reference is a reference. For example, if
+<code>x</code> is of type <code>&amp;[T, R]</code>, then the path
+<code>x-&gt;y-&gt;z</code> (assuming <code>z</code> is a record slot
+with type <code>U</code>) is of type <code>&amp;[U, R]</code>.</p></li>
 </ol>
 <p>Examples:</p>
 <pre class="austral"><code>pos.x
 star-&gt;pos.ra
 stars[23]-&gt;distance</code></pre>
 <h2 id="expr-deref">Dereference Expression</h2>
-<p>If <code>e</code> is a reference to a value of type <code>T</code>, then:</p>
+<p>If <code>e</code> is a reference to a value of type <code>T</code>,
+then:</p>
 <pre class="austral"><code>!e</code></pre>
-<p>is a dereferencing expression that evaluates to the referenced value of type <code>T</code>.</p>
+<p>is a dereferencing expression that evaluates to the referenced value
+of type <code>T</code>.</p>
 <h2 id="expr-borrow">Borrow Expressions</h2>
-<p>If <code>x</code> is a variable of a linear type <code>T</code>, then:</p>
+<p>If <code>x</code> is a variable of a linear type <code>T</code>,
+then:</p>
 <pre><code>&amp;x</code></pre>
-<p>is an anonymous read-only borrow, and is an expression of type <code>&amp;[T, R]</code>, where <code>R</code> is a nameless region, and</p>
+<p>is an anonymous read-only borrow, and is an expression of type
+<code>&amp;[T, R]</code>, where <code>R</code> is a nameless region,
+and</p>
 <pre><code>&amp;!x</code></pre>
-<p>is an anonymous read-write borrow, and is an expression of type <code>&amp;![T, R]</code>, where <code>R</code> is a nameless region.</p>
-<p>Borrow expressions cannot escape the statement where they appear. That is, if we write:</p>
+<p>is an anonymous read-write borrow, and is an expression of type
+<code>&amp;![T, R]</code>, where <code>R</code> is a nameless
+region.</p>
+<p>Borrow expressions cannot escape the statement where they appear.
+That is, if we write:</p>
 <pre><code>let r: &amp;[T, R] := &amp;x;</code></pre>
-<p>This will be rejected by the compiler because the region name <code>R</code> is introduced nowhere.</p>
+<p>This will be rejected by the compiler because the region name
+<code>R</code> is introduced nowhere.</p>
 <h2 id="expr-sizeof">sizeof Expression</h2>
 <p>If <code>T</code> is a type specifier, then:</p>
 <pre class="austral"><code>sizeof(T)</code></pre>
-<p>is an expression of type <code>Index</code> that evaluates to the size of the type in bytes.</p>
+<p>is an expression of type <code>Index</code> that evaluates to the
+size of the type in bytes.</p>
 <h1 id="linearity">Linearity Checking</h1>
 <p>This section describes Austral’s linearity checking rules.</p>
 <p>The rules for linear types:</p>
 <ol type="1">
-<li><p>A type is linear if it physically contains a linear type, or is declared to be linear (belongs to either the <code>Linear</code> or <code>Type</code> universes).</p></li>
-<li><p>A variable <code>x</code> of a linear type must be used once and exactly once in the scope in which it is defined, where “used once” means:</p>
+<li><p>A type is linear if it physically contains a linear type, or is
+declared to be linear (belongs to either the <code>Linear</code> or
+<code>Type</code> universes).</p></li>
+<li><p>A variable <code>x</code> of a linear type must be used once and
+exactly once in the scope in which it is defined, where “used once”
+means:</p>
 <ol type="1">
-<li><p>If the scope is a single block with no changes in control flow, a variable that appears once anywhere in the block is used once.</p></li>
-<li><p>If the scope includes an <code>if</code> statement, the variable must be used once in every branch or it must not appear in the statement.</p></li>
-<li><p>Analogously, if the scope includes a <code>case</code> statement, the variable must be used once in every <code>when</code> clause, or it must not appear in the statement.</p></li>
-<li><p>If the scope includes a loop, the variable may not appear in the loop body or the loop start/end/conditions (because it would be used once for each iteration). Linear variables can be <em>defined</em> inside loop bodies, however.</p></li>
+<li><p>If the scope is a single block with no changes in control flow, a
+variable that appears once anywhere in the block is used once.</p></li>
+<li><p>If the scope includes an <code>if</code> statement, the variable
+must be used once in every branch or it must not appear in the
+statement.</p></li>
+<li><p>Analogously, if the scope includes a <code>case</code> statement,
+the variable must be used once in every <code>when</code> clause, or it
+must not appear in the statement.</p></li>
+<li><p>If the scope includes a loop, the variable may not appear in the
+loop body or the loop start/end/conditions (because it would be used
+once for each iteration). Linear variables can be <em>defined</em>
+inside loop bodies, however.</p></li>
 <li><p>A borrow statement does not count as using the variable.</p></li>
-<li><p>Neither does a path that ends in a free value (this is the one concession to programmer ergonomics).</p></li>
+<li><p>Neither does a path that ends in a free value (this is the one
+concession to programmer ergonomics).</p></li>
 </ol></li>
-<li><p>When a variable is used, it is said to be consumed. Afterwards, it is said to be in the consumed state.</p></li>
-<li><p>If a variable is never consumed, or is consumed more than once, the compiler signals an error.</p></li>
-<li><p>Linear values which are not stored in variables cannot be discarded.</p></li>
-<li><p>You cannot return from a function while there are any unconsumed linear values.</p></li>
-<li><p>A borrowed variable cannot appear in the body of the statement that borrows it.</p></li>
+<li><p>When a variable is used, it is said to be consumed. Afterwards,
+it is said to be in the consumed state.</p></li>
+<li><p>If a variable is never consumed, or is consumed more than once,
+the compiler signals an error.</p></li>
+<li><p>Linear values which are not stored in variables cannot be
+discarded.</p></li>
+<li><p>You cannot return from a function while there are any unconsumed
+linear values.</p></li>
+<li><p>A borrowed variable cannot appear in the body of the statement
+that borrows it.</p></li>
 </ol>
 <h1 id="builtin">Built-In Modules</h1>
-<p>This section describes Austral’s built-in modules, those which are available everywhere.</p>
+<p>This section describes Austral’s built-in modules, those which are
+available everywhere.</p>
 <h2 id="austral.memory">Austral.Memory Module</h2>
-<p>The <code>Austral.Memory</code> module contains types and functions for manipulating pointers and memory.</p>
+<p>The <code>Austral.Memory</code> module contains types and functions
+for manipulating pointers and memory.</p>
 <h3 id="austral.memory-pointer"><code>Pointer</code> Type</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>type Pointer[T: Type]: Free;</code></pre>
 <p>Description:</p>
 <p>This is the type of nullable pointers.</p>
-<h3 id="austral.memory-nullpointer"><code>nullPointer</code> Function</h3>
+<h3 id="austral.memory-nullpointer"><code>nullPointer</code>
+Function</h3>
 <pre class="austral"><code>generic [T: Type]
 function nullPointer(): Pointer[T];</code></pre>
 <p>Description:</p>
@@ -2293,13 +3941,19 @@ function nullPointer(): Pointer[T];</code></pre>
 <pre class="austral"><code>generic [T: Type]
 function allocate(): Pointer[T];</code></pre>
 <p>Description:</p>
-<p>Allocates enough memory to hold a single value of type <code>T</code>. Analogous to <a href="https://en.cppreference.com/w/c/memory/calloc">calloc</a> with a <code>count</code> argument of 1.</p>
-<h3 id="austral.memory-allocate-buffer"><code>allocateBuffer</code> Function</h3>
+<p>Allocates enough memory to hold a single value of type
+<code>T</code>. Analogous to <a
+href="https://en.cppreference.com/w/c/memory/calloc">calloc</a> with a
+<code>count</code> argument of 1.</p>
+<h3 id="austral.memory-allocate-buffer"><code>allocateBuffer</code>
+Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
 function allocateBuffer(count: Index): Pointer[T];</code></pre>
 <p>Description:</p>
-<p>Allocates enough memory to hold <code>count</code> items of type <code>T</code> in a contiguous chunk of memory. Analogous to <a href="https://en.cppreference.com/w/c/memory/calloc">calloc</a>.</p>
+<p>Allocates enough memory to hold <code>count</code> items of type
+<code>T</code> in a contiguous chunk of memory. Analogous to <a
+href="https://en.cppreference.com/w/c/memory/calloc">calloc</a>.</p>
 <p><code>count</code> must be at least 1.</p>
 <h3 id="austral.memory-load"><code>load</code> Function</h3>
 <p>Declaration:</p>
@@ -2312,7 +3966,8 @@ function load(pointer: Pointer[T]): T;</code></pre>
 <pre class="austral"><code>generic [T: Type]
 function store(pointer: Pointer[T], value: T): Unit;</code></pre>
 <p>Description:</p>
-<p>Stores <code>value</code> at the location pointed to by <code>pointer</code>.</p>
+<p>Stores <code>value</code> at the location pointed to by
+<code>pointer</code>.</p>
 <h3 id="austral.memory-deallocate"><code>deallocate</code> Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
@@ -2324,32 +3979,39 @@ function deallocate(pointer: Pointer[T]): Unit;</code></pre>
 <pre class="austral"><code>generic [T: Type, R: Region]
 function loadRead(ref: &amp;[Pointer[T], R]): Reference[T, R];</code></pre>
 <p>Description:</p>
-<p>Takes a reference to a pointer, and turns it into a reference to the pointed-to value.</p>
+<p>Takes a reference to a pointer, and turns it into a reference to the
+pointed-to value.</p>
 <h3 id="austral.memory-loadwrite"><code>loadWrite</code> Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type, R: Region]
 function loadWrite(ref: &amp;![Pointer[T], R]): WriteReference[T, R];</code></pre>
 <p>Description:</p>
-<p>Takes a write reference to a pointer, and turns it into a write reference to the pointed-to value.</p>
-<h3 id="austral.memory-resizearray"><code>resizeArray</code> Function</h3>
+<p>Takes a write reference to a pointer, and turns it into a write
+reference to the pointed-to value.</p>
+<h3 id="austral.memory-resizearray"><code>resizeArray</code>
+Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
 function resizeArray(array: Pointer[T], size: Index): Pointer[T];</code></pre>
 <p>Description:</p>
-<p>Resizes the given array, returning <code>Some</code> with the new location if allocation succeeded, and <code>None</code> otherwise.</p>
+<p>Resizes the given array, returning <code>Some</code> with the new
+location if allocation succeeded, and <code>None</code> otherwise.</p>
 <h3 id="austral.memory-memmove"><code>memmove</code> Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type, U: Type]
 function memmove(source: Pointer[T], destination: Pointer[U], count: Index): Unit;</code></pre>
 <p>Description:</p>
-<p>Moves the <code>count</code> bytes stored at <code>source</code> to <code>destination</code>.</p>
+<p>Moves the <code>count</code> bytes stored at <code>source</code> to
+<code>destination</code>.</p>
 <h3 id="austral.memory-memcpy"><code>memcpy</code> Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type, U: Type]
 function memcpy(source: Pointer[T], destination: Pointer[U], count: Index): Unit;</code></pre>
 <p>Description:</p>
-<p>Copies the <code>count</code> bytes stored at <code>source</code> to <code>destination</code>.</p>
-<h3 id="austral.memory-positiveoffset"><code>positiveOffset</code> Function</h3>
+<p>Copies the <code>count</code> bytes stored at <code>source</code> to
+<code>destination</code>.</p>
+<h3 id="austral.memory-positiveoffset"><code>positiveOffset</code>
+Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
 function positiveOffset(pointer: Pointer[T], offset: Index): Pointer[T];</code></pre>
@@ -2358,7 +4020,8 @@ function positiveOffset(pointer: Pointer[T], offset: Index): Pointer[T];</code><
 <p><span class="math display">\[
 \text{pointer} + \text{sizeof}(\tau) \times \text{offset}
 \]</span></p>
-<h3 id="austral.memory-negativeoffset"><code>negativeOffset</code> Function</h3>
+<h3 id="austral.memory-negativeoffset"><code>negativeOffset</code>
+Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
 function negativeOffset(pointer: Pointer[T], offset: Index): Pointer[T];</code></pre>
@@ -2368,7 +4031,8 @@ function negativeOffset(pointer: Pointer[T], offset: Index): Pointer[T];</code><
 \text{pointer} - \text{sizeof}(\tau) \times \text{offset}
 \]</span></p>
 <h2 id="austral.pervasive">Austral.Pervasive Module</h2>
-<p>The <code>Austral.Pervasive</code> module exports declarations which are imported by every module.</p>
+<p>The <code>Austral.Pervasive</code> module exports declarations which
+are imported by every module.</p>
 <h3 id="austral.pervasive-option"><code>Option</code> Type</h3>
 <p>Definition:</p>
 <pre class="austral"><code>union Option[T: Type]: Type is
@@ -2377,7 +4041,10 @@ function negativeOffset(pointer: Pointer[T], offset: Index): Pointer[T];</code><
         value: T;
 end;</code></pre>
 <p>Description:</p>
-<p>The <code>Option</code> is used to represent values that might be empty, for example, the return type of a function that retrieves a value from a dictionary by key might return <code>None</code> if the key does not exist and <code>Some</code> otherwise.</p>
+<p>The <code>Option</code> is used to represent values that might be
+empty, for example, the return type of a function that retrieves a value
+from a dictionary by key might return <code>None</code> if the key does
+not exist and <code>Some</code> otherwise.</p>
 <h3 id="austral.pervasive-either"><code>Either</code> Type</h3>
 <p>Definition:</p>
 <pre class="austral"><code>union Either[L: Type, R: Type]: Type is
@@ -2387,46 +4054,48 @@ end;</code></pre>
         right: R;
 end;</code></pre>
 <p>Description:</p>
-<p>The <code>Either</code> type is used to represent values which may have one of two distinct possibilities. For example, a function might return a value of type <code>Either[Error, Result]</code>.</p>
-<h3 id="austral.pervasive-deref"><code>deref</code> Function</h3>
-<p>Declaration:</p>
-<pre class="austral"><code>generic [T: Free, R: Region]
-function deref(ref: &amp;[T, R]): T;</code></pre>
-<p>Description:</p>
-<p>The <code>deref</code> function loads the value pointed to by a read reference.</p>
-<h3 id="austral.pervasive-derefwrite"><code>derefWrite</code> Function</h3>
-<p>Declaration:</p>
-<pre class="austral"><code>generic [T: Free, R: Region]
-function derefWrite(ref: &amp;![T, R]): T;</code></pre>
-<p>Description:</p>
-<p>The <code>derefWrite</code> function loads the value pointed to by a write reference.</p>
-<h3 id="austral.pervasive-fixedarraysize"><code>fixedArraySize</code> Function</h3>
+<p>The <code>Either</code> type is used to represent values which may
+have one of two distinct possibilities. For example, a function might
+return a value of type <code>Either[Error, Result]</code>.</p>
+<h3 id="austral.pervasive-fixedarraysize"><code>fixedArraySize</code>
+Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>generic [T: Type]
 function fixedArraySize(arr: FixedArray[T]): Nat64;</code></pre>
 <p>Description:</p>
-<p>The <code>fixedArraySize</code> function returns the size of a fixed array.</p>
+<p>The <code>fixedArraySize</code> function returns the size of a fixed
+array.</p>
 <h3 id="austral.pervasive-abort"><code>abort</code> Function</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>function abort(message: Fixed_Array[Nat8]): Unit;</code></pre>
 <p>Description:</p>
-<p>The <code>abort</code> function prints the given message to standard error and aborts the program.</p>
-<h3 id="austral.pervasive-rootcapability"><code>RootCapability</code> Type</h3>
+<p>The <code>abort</code> function prints the given message to standard
+error and aborts the program.</p>
+<h3 id="austral.pervasive-rootcapability"><code>RootCapability</code>
+Type</h3>
 <p>Declaration:</p>
 <pre class="austral"><code>type RootCapability : Linear;</code></pre>
 <p>Description:</p>
-<p>The <code>RootCapability</code> type is meant to be the root of the capability hierarchy.</p>
-<p>The entrypoint function of an Austral program takes a single value of type <code>RootCapability</code>. This is the highest permission level, available only at the start of the program.</p>
-<h3 id="austral.pervasive-surrenderroot"><code>surrenderRoot</code> Function</h3>
+<p>The <code>RootCapability</code> type is meant to be the root of the
+capability hierarchy.</p>
+<p>The entrypoint function of an Austral program takes a single value of
+type <code>RootCapability</code>. This is the highest permission level,
+available only at the start of the program.</p>
+<h3 id="austral.pervasive-surrenderroot"><code>surrenderRoot</code>
+Function</h3>
 <pre class="austral"><code>function surrenderRoot(cap: RootCapability): Unit;</code></pre>
-<p>The <code>surrenderRoot</code> function consumes the root capability. Beyond this point the program can’t do anything effectful, except through unsafe FFI interfaces.</p>
+<p>The <code>surrenderRoot</code> function consumes the root capability.
+Beyond this point the program can’t do anything effectful, except
+through unsafe FFI interfaces.</p>
 <h3 id="austral.pervasive-exitcode"><code>ExitCode</code> Type</h3>
 <pre class="austral"><code>union ExitCode: Free is
     case ExitSuccess;
     case ExitFailure;
 end;</code></pre>
-<p>The <code>ExitCode</code> type is the return type of entrypoint functions.</p>
-<h3 id="austral.pervasive-integer-bound-constants">Integer Bound Constants</h3>
+<p>The <code>ExitCode</code> type is the return type of entrypoint
+functions.</p>
+<h3 id="austral.pervasive-integer-bound-constants">Integer Bound
+Constants</h3>
 <p>Declarations:</p>
 <pre class="austral"><code>constant maximum_nat8: Nat8;
 constant maximum_nat16: Nat16;
@@ -2445,8 +4114,11 @@ constant maximum_int32: Int32;
 constant minimum_int64: Int64;
 constant maximum_int64: Int64;</code></pre>
 <p>Description:</p>
-<p>These constants define the minimum and maximum values that can be stored in different integer types.</p>
-<h3 id="austral.pervasive-trappingarithmetic"><code>TrappingArithmetic</code> Typeclass</h3>
+<p>These constants define the minimum and maximum values that can be
+stored in different integer types.</p>
+<h3
+id="austral.pervasive-trappingarithmetic"><code>TrappingArithmetic</code>
+Typeclass</h3>
 <p>Definition:</p>
 <pre class="austral"><code>typeclass TrappingArithmetic(T: Type) is
     method trappingAdd(lhs: T, rhs: T): T;
@@ -2455,8 +4127,11 @@ constant maximum_int64: Int64;</code></pre>
     method trappingDivide(lhs: T, rhs: T): T;
 end;</code></pre>
 <p>Description:</p>
-<p>The <code>TrappingArithmetic</code> typeclass defines methods for performing arithmetic that aborts on overflow errors.</p>
-<h3 id="austral.pervasive-modularithmetic"><code>ModularArithmetic</code> Typeclass</h3>
+<p>The <code>TrappingArithmetic</code> typeclass defines methods for
+performing arithmetic that aborts on overflow errors.</p>
+<h3
+id="austral.pervasive-modularithmetic"><code>ModularArithmetic</code>
+Typeclass</h3>
 <p>Definition:</p>
 <pre class="austral"><code>typeclass ModularArithmetic(T: Type) is
     method modularAdd(lhs: T, rhs: T): T;
@@ -2465,7 +4140,9 @@ end;</code></pre>
     method modularDivide(lhs: T, rhs: T): T;
 end;</code></pre>
 <p>Description:</p>
-<p>The <code>ModularArithmetic</code> typeclass defines methods for performing arithmetic that wraps around without abort on overflow errors.</p>
+<p>The <code>ModularArithmetic</code> typeclass defines methods for
+performing arithmetic that wraps around without abort on overflow
+errors.</p>
 <h3 id="austral.pervasive-typeclass-instances">Typeclass Instances</h3>
 <p>Declarations:</p>
 <pre class="austral"><code>instance TrappingArithmetic(Nat8);
@@ -2487,27 +4164,41 @@ instance ModularArithmetic(Int32);
 instance ModularArithmetic(Nat64);
 instance ModularArithmetic(Int64);</code></pre>
 <p>Description:</p>
-<p>These are the built-in instances of the <code>TrappingArithmetic</code> and <code>ModularArithmetic</code> typeclasses.</p>
+<p>These are the built-in instances of the
+<code>TrappingArithmetic</code> and <code>ModularArithmetic</code>
+typeclasses.</p>
 <h1 id="ffi">Foreign Interfaces</h1>
-<p>This section describes Austral’s support for communicating with the outside world.</p>
+<p>This section describes Austral’s support for communicating with the
+outside world.</p>
 <h2 id="c-ffi">The C Interface</h2>
 <p>This section decribes Austral’s support for calling C code.</p>
 <h3 id="c-ffi-functions">Functions</h3>
-<p>To call a foreign function, we must declare it. The syntax is the same as that of ordinary functions, except in the body of the function definition.</p>
+<p>To call a foreign function, we must declare it. The syntax is the
+same as that of ordinary functions, except in the body of the function
+definition.</p>
 <p>For example, consider the C function:</p>
 <pre><code>double sum(double* array, size_t length);</code></pre>
-<p>The <a href="/spec/declarations#function-declaration">declaration</a> of this function would look like:</p>
+<p>The <a href="/spec/declarations#function-declaration">declaration</a>
+of this function would look like:</p>
 <pre><code>function Sum(array: Pointer[Float64], length: Index): Float64;</code></pre>
-<p>Note that, as in regular functions, the declaration is only needed if the function is to be public in the module in which it is defined.</p>
+<p>Note that, as in regular functions, the declaration is only needed if
+the function is to be public in the module in which it is defined.</p>
 <p>The definition would look like:</p>
 <pre><code>function Sum(array: Pointer[Float64], length: Index): Float64 is
     pragma Foreign_Import(External_Name =&gt; &quot;sum&quot;);
 end;</code></pre>
-<p>That is, instead of a statement, there is only a <code>Foreign_Import</code> pragma, which takes a named argument <code>External_Name</code>, which must be a string constant with the name of the function to import.</p>
-<p>Naturally, the function’s parameter list and return type must match those of the foreign function. See the following section for how C types are mapped to Austral types.</p>
+<p>That is, instead of a statement, there is only a
+<code>Foreign_Import</code> pragma, which takes a named argument
+<code>External_Name</code>, which must be a string constant with the
+name of the function to import.</p>
+<p>Naturally, the function’s parameter list and return type must match
+those of the foreign function. See the following section for how C types
+are mapped to Austral types.</p>
 <h3 id="c-ffi-mapping-types">Mapping Types</h3>
-<p>In the following table, the C type on the first column corresponds to the Austral type on the second column.</p>
-<p>Only the types in the second column are permitted to appear in the parameter list and return type of a foreign function.</p>
+<p>In the following table, the C type on the first column corresponds to
+the Austral type on the second column.</p>
+<p>Only the types in the second column are permitted to appear in the
+parameter list and return type of a foreign function.</p>
 <table>
 <thead>
 <tr class="header">
@@ -2605,84 +4296,363 @@ end;</code></pre>
 </ol>
 <h1 id="license">Appendix A: GNU Free Documentation License</h1>
 <p>Version 1.3, 3 November 2008</p>
-<p>Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc. <a href="https://fsf.org/" class="uri">https://fsf.org/</a></p>
-<p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.</p>
+<p>Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation,
+Inc. <a href="https://fsf.org/" class="uri">https://fsf.org/</a></p>
+<p>Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.</p>
 <h4 id="preamble">0. PREAMBLE</h4>
-<p>The purpose of this License is to make a manual, textbook, or other functional and useful document “free” in the sense of freedom: to assure everyone the effective freedom to copy and redistribute it, with or without modifying it, either commercially or noncommercially. Secondarily, this License preserves for the author and publisher a way to get credit for their work, while not being considered responsible for modifications made by others.</p>
-<p>This License is a kind of “copyleft”, which means that derivative works of the document must themselves be free in the same sense. It complements the GNU General Public License, which is a copyleft license designed for free software.</p>
-<p>We have designed this License in order to use it for manuals for free software, because free software needs free documentation: a free program should come with manuals providing the same freedoms that the software does. But this License is not limited to software manuals; it can be used for any textual work, regardless of subject matter or whether it is published as a printed book. We recommend this License principally for works whose purpose is instruction or reference.</p>
-<h4 id="applicability-and-definitions">1. APPLICABILITY AND DEFINITIONS</h4>
-<p>This License applies to any manual or other work, in any medium, that contains a notice placed by the copyright holder saying it can be distributed under the terms of this License. Such a notice grants a world-wide, royalty-free license, unlimited in duration, to use that work under the conditions stated herein. The “Document”, below, refers to any such manual or work. Any member of the public is a licensee, and is addressed as “you”. You accept the license if you copy, modify or distribute the work in a way requiring permission under copyright law.</p>
-<p>A “Modified Version” of the Document means any work containing the Document or a portion of it, either copied verbatim, or with modifications and/or translated into another language.</p>
-<p>A “Secondary Section” is a named appendix or a front-matter section of the Document that deals exclusively with the relationship of the publishers or authors of the Document to the Document’s overall subject (or to related matters) and contains nothing that could fall directly within that overall subject. (Thus, if the Document is in part a textbook of mathematics, a Secondary Section may not explain any mathematics.) The relationship could be a matter of historical connection with the subject or with related matters, or of legal, commercial, philosophical, ethical or political position regarding them.</p>
-<p>The “Invariant Sections” are certain Secondary Sections whose titles are designated, as being those of Invariant Sections, in the notice that says that the Document is released under this License. If a section does not fit the above definition of Secondary then it is not allowed to be designated as Invariant. The Document may contain zero Invariant Sections. If the Document does not identify any Invariant Sections then there are none.</p>
-<p>The “Cover Texts” are certain short passages of text that are listed, as Front-Cover Texts or Back-Cover Texts, in the notice that says that the Document is released under this License. A Front-Cover Text may be at most 5 words, and a Back-Cover Text may be at most 25 words.</p>
-<p>A “Transparent” copy of the Document means a machine-readable copy, represented in a format whose specification is available to the general public, that is suitable for revising the document straightforwardly with generic text editors or (for images composed of pixels) generic paint programs or (for drawings) some widely available drawing editor, and that is suitable for input to text formatters or for automatic translation to a variety of formats suitable for input to text formatters. A copy made in an otherwise Transparent file format whose markup, or absence of markup, has been arranged to thwart or discourage subsequent modification by readers is not Transparent. An image format is not Transparent if used for any substantial amount of text. A copy that is not “Transparent” is called “Opaque”.</p>
-<p>Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo input format, LaTeX input format, SGML or XML using a publicly available DTD, and standard-conforming simple HTML, PostScript or PDF designed for human modification. Examples of transparent image formats include PNG, XCF and JPG. Opaque formats include proprietary formats that can be read and edited only by proprietary word processors, SGML or XML for which the DTD and/or processing tools are not generally available, and the machine-generated HTML, PostScript or PDF produced by some word processors for output purposes only.</p>
-<p>The “Title Page” means, for a printed book, the title page itself, plus such following pages as are needed to hold, legibly, the material this License requires to appear in the title page. For works in formats which do not have any title page as such, “Title Page” means the text near the most prominent appearance of the work’s title, preceding the beginning of the body of the text.</p>
-<p>The “publisher” means any person or entity that distributes copies of the Document to the public.</p>
-<p>A section “Entitled XYZ” means a named subunit of the Document whose title either is precisely XYZ or contains XYZ in parentheses following text that translates XYZ in another language. (Here XYZ stands for a specific section name mentioned below, such as “Acknowledgements”, “Dedications”, “Endorsements”, or “History”.) To “Preserve the Title” of such a section when you modify the Document means that it remains a section “Entitled XYZ” according to this definition.</p>
-<p>The Document may include Warranty Disclaimers next to the notice which states that this License applies to the Document. These Warranty Disclaimers are considered to be included by reference in this License, but only as regards disclaiming warranties: any other implication that these Warranty Disclaimers may have is void and has no effect on the meaning of this License.</p>
+<p>The purpose of this License is to make a manual, textbook, or other
+functional and useful document “free” in the sense of freedom: to assure
+everyone the effective freedom to copy and redistribute it, with or
+without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible for
+modifications made by others.</p>
+<p>This License is a kind of “copyleft”, which means that derivative
+works of the document must themselves be free in the same sense. It
+complements the GNU General Public License, which is a copyleft license
+designed for free software.</p>
+<p>We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free program
+should come with manuals providing the same freedoms that the software
+does. But this License is not limited to software manuals; it can be
+used for any textual work, regardless of subject matter or whether it is
+published as a printed book. We recommend this License principally for
+works whose purpose is instruction or reference.</p>
+<h4 id="applicability-and-definitions">1. APPLICABILITY AND
+DEFINITIONS</h4>
+<p>This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License. Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein. The “Document”, below, refers
+to any such manual or work. Any member of the public is a licensee, and
+is addressed as “you”. You accept the license if you copy, modify or
+distribute the work in a way requiring permission under copyright
+law.</p>
+<p>A “Modified Version” of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.</p>
+<p>A “Secondary Section” is a named appendix or a front-matter section
+of the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document’s overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject. (Thus, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.) The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.</p>
+<p>The “Invariant Sections” are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice that
+says that the Document is released under this License. If a section does
+not fit the above definition of Secondary then it is not allowed to be
+designated as Invariant. The Document may contain zero Invariant
+Sections. If the Document does not identify any Invariant Sections then
+there are none.</p>
+<p>The “Cover Texts” are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License. A Front-Cover Text may be
+at most 5 words, and a Back-Cover Text may be at most 25 words.</p>
+<p>A “Transparent” copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the general
+public, that is suitable for revising the document straightforwardly
+with generic text editors or (for images composed of pixels) generic
+paint programs or (for drawings) some widely available drawing editor,
+and that is suitable for input to text formatters or for automatic
+translation to a variety of formats suitable for input to text
+formatters. A copy made in an otherwise Transparent file format whose
+markup, or absence of markup, has been arranged to thwart or discourage
+subsequent modification by readers is not Transparent. An image format
+is not Transparent if used for any substantial amount of text. A copy
+that is not “Transparent” is called “Opaque”.</p>
+<p>Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML or
+XML using a publicly available DTD, and standard-conforming simple HTML,
+PostScript or PDF designed for human modification. Examples of
+transparent image formats include PNG, XCF and JPG. Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the machine-generated
+HTML, PostScript or PDF produced by some word processors for output
+purposes only.</p>
+<p>The “Title Page” means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page. For works in formats
+which do not have any title page as such, “Title Page” means the text
+near the most prominent appearance of the work’s title, preceding the
+beginning of the body of the text.</p>
+<p>The “publisher” means any person or entity that distributes copies of
+the Document to the public.</p>
+<p>A section “Entitled XYZ” means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language. (Here XYZ stands for a
+specific section name mentioned below, such as “Acknowledgements”,
+“Dedications”, “Endorsements”, or “History”.) To “Preserve the Title” of
+such a section when you modify the Document means that it remains a
+section “Entitled XYZ” according to this definition.</p>
+<p>The Document may include Warranty Disclaimers next to the notice
+which states that this License applies to the Document. These Warranty
+Disclaimers are considered to be included by reference in this License,
+but only as regards disclaiming warranties: any other implication that
+these Warranty Disclaimers may have is void and has no effect on the
+meaning of this License.</p>
 <h4 id="verbatim-copying">2. VERBATIM COPYING</h4>
-<p>You may copy and distribute the Document in any medium, either commercially or noncommercially, provided that this License, the copyright notices, and the license notice saying this License applies to the Document are reproduced in all copies, and that you add no other conditions whatsoever to those of this License. You may not use technical measures to obstruct or control the reading or further copying of the copies you make or distribute. However, you may accept compensation in exchange for copies. If you distribute a large enough number of copies you must also follow the conditions in section 3.</p>
-<p>You may also lend copies, under the same conditions stated above, and you may publicly display copies.</p>
+<p>You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies to
+the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License. You may not use
+technical measures to obstruct or control the reading or further copying
+of the copies you make or distribute. However, you may accept
+compensation in exchange for copies. If you distribute a large enough
+number of copies you must also follow the conditions in section 3.</p>
+<p>You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.</p>
 <h4 id="copying-in-quantity">3. COPYING IN QUANTITY</h4>
-<p>If you publish printed copies (or copies in media that commonly have printed covers) of the Document, numbering more than 100, and the Document’s license notice requires Cover Texts, you must enclose the copies in covers that carry, clearly and legibly, all these Cover Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on the back cover. Both covers must also clearly and legibly identify you as the publisher of these copies. The front cover must present the full title with all words of the title equally prominent and visible. You may add other material on the covers in addition. Copying with changes limited to the covers, as long as they preserve the title of the Document and satisfy these conditions, can be treated as verbatim copying in other respects.</p>
-<p>If the required texts for either cover are too voluminous to fit legibly, you should put the first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto adjacent pages.</p>
-<p>If you publish or distribute Opaque copies of the Document numbering more than 100, you must either include a machine-readable Transparent copy along with each Opaque copy, or state in or with each Opaque copy a computer-network location from which the general network-using public has access to download using public-standard network protocols a complete Transparent copy of the Document, free of added material. If you use the latter option, you must take reasonably prudent steps, when you begin distribution of Opaque copies in quantity, to ensure that this Transparent copy will remain thus accessible at the stated location until at least one year after the last time you distribute an Opaque copy (directly or through your agents or retailers) of that edition to the public.</p>
-<p>It is requested, but not required, that you contact the authors of the Document well before redistributing any large number of copies, to give them a chance to provide you with an updated version of the Document.</p>
+<p>If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document’s license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover Texts:
+Front-Cover Texts on the front cover, and Back-Cover Texts on the back
+cover. Both covers must also clearly and legibly identify you as the
+publisher of these copies. The front cover must present the full title
+with all words of the title equally prominent and visible. You may add
+other material on the covers in addition. Copying with changes limited
+to the covers, as long as they preserve the title of the Document and
+satisfy these conditions, can be treated as verbatim copying in other
+respects.</p>
+<p>If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.</p>
+<p>If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy a
+computer-network location from which the general network-using public
+has access to download using public-standard network protocols a
+complete Transparent copy of the Document, free of added material. If
+you use the latter option, you must take reasonably prudent steps, when
+you begin distribution of Opaque copies in quantity, to ensure that this
+Transparent copy will remain thus accessible at the stated location
+until at least one year after the last time you distribute an Opaque
+copy (directly or through your agents or retailers) of that edition to
+the public.</p>
+<p>It is requested, but not required, that you contact the authors of
+the Document well before redistributing any large number of copies, to
+give them a chance to provide you with an updated version of the
+Document.</p>
 <h4 id="modifications">4. MODIFICATIONS</h4>
-<p>You may copy and distribute a Modified Version of the Document under the conditions of sections 2 and 3 above, provided that you release the Modified Version under precisely this License, with the Modified Version filling the role of the Document, thus licensing distribution and modification of the Modified Version to whoever possesses a copy of it. In addition, you must do these things in the Modified Version:</p>
+<p>You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release the
+Modified Version under precisely this License, with the Modified Version
+filling the role of the Document, thus licensing distribution and
+modification of the Modified Version to whoever possesses a copy of it.
+In addition, you must do these things in the Modified Version:</p>
 <ul>
-<li>A. Use in the Title Page (and on the covers, if any) a title distinct from that of the Document, and from those of previous versions (which should, if there were any, be listed in the History section of the Document). You may use the same title as a previous version if the original publisher of that version gives permission.</li>
-<li>B. List on the Title Page, as authors, one or more persons or entities responsible for authorship of the modifications in the Modified Version, together with at least five of the principal authors of the Document (all of its principal authors, if it has fewer than five), unless they release you from this requirement.</li>
-<li>C. State on the Title page the name of the publisher of the Modified Version, as the publisher.</li>
+<li>A. Use in the Title Page (and on the covers, if any) a title
+distinct from that of the Document, and from those of previous versions
+(which should, if there were any, be listed in the History section of
+the Document). You may use the same title as a previous version if the
+original publisher of that version gives permission.</li>
+<li>B. List on the Title Page, as authors, one or more persons or
+entities responsible for authorship of the modifications in the Modified
+Version, together with at least five of the principal authors of the
+Document (all of its principal authors, if it has fewer than five),
+unless they release you from this requirement.</li>
+<li>C. State on the Title page the name of the publisher of the Modified
+Version, as the publisher.</li>
 <li>D. Preserve all the copyright notices of the Document.</li>
-<li>E. Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.</li>
-<li>F. Include, immediately after the copyright notices, a license notice giving the public permission to use the Modified Version under the terms of this License, in the form shown in the Addendum below.</li>
-<li>G. Preserve in that license notice the full lists of Invariant Sections and required Cover Texts given in the Document’s license notice.</li>
+<li>E. Add an appropriate copyright notice for your modifications
+adjacent to the other copyright notices.</li>
+<li>F. Include, immediately after the copyright notices, a license
+notice giving the public permission to use the Modified Version under
+the terms of this License, in the form shown in the Addendum below.</li>
+<li>G. Preserve in that license notice the full lists of Invariant
+Sections and required Cover Texts given in the Document’s license
+notice.</li>
 <li>H. Include an unaltered copy of this License.</li>
-<li>I. Preserve the section Entitled “History”, Preserve its Title, and add to it an item stating at least the title, year, new authors, and publisher of the Modified Version as given on the Title Page. If there is no section Entitled “History” in the Document, create one stating the title, year, authors, and publisher of the Document as given on its Title Page, then add an item describing the Modified Version as stated in the previous sentence.</li>
-<li>J. Preserve the network location, if any, given in the Document for public access to a Transparent copy of the Document, and likewise the network locations given in the Document for previous versions it was based on. These may be placed in the “History” section. You may omit a network location for a work that was published at least four years before the Document itself, or if the original publisher of the version it refers to gives permission.</li>
-<li>K. For any section Entitled “Acknowledgements” or “Dedications”, Preserve the Title of the section, and preserve in the section all the substance and tone of each of the contributor acknowledgements and/or dedications given therein.</li>
-<li>L. Preserve all the Invariant Sections of the Document, unaltered in their text and in their titles. Section numbers or the equivalent are not considered part of the section titles.</li>
-<li>M. Delete any section Entitled “Endorsements”. Such a section may not be included in the Modified Version.</li>
-<li>N. Do not retitle any existing section to be Entitled “Endorsements” or to conflict in title with any Invariant Section.</li>
+<li>I. Preserve the section Entitled “History”, Preserve its Title, and
+add to it an item stating at least the title, year, new authors, and
+publisher of the Modified Version as given on the Title Page. If there
+is no section Entitled “History” in the Document, create one stating the
+title, year, authors, and publisher of the Document as given on its
+Title Page, then add an item describing the Modified Version as stated
+in the previous sentence.</li>
+<li>J. Preserve the network location, if any, given in the Document for
+public access to a Transparent copy of the Document, and likewise the
+network locations given in the Document for previous versions it was
+based on. These may be placed in the “History” section. You may omit a
+network location for a work that was published at least four years
+before the Document itself, or if the original publisher of the version
+it refers to gives permission.</li>
+<li>K. For any section Entitled “Acknowledgements” or “Dedications”,
+Preserve the Title of the section, and preserve in the section all the
+substance and tone of each of the contributor acknowledgements and/or
+dedications given therein.</li>
+<li>L. Preserve all the Invariant Sections of the Document, unaltered in
+their text and in their titles. Section numbers or the equivalent are
+not considered part of the section titles.</li>
+<li>M. Delete any section Entitled “Endorsements”. Such a section may
+not be included in the Modified Version.</li>
+<li>N. Do not retitle any existing section to be Entitled “Endorsements”
+or to conflict in title with any Invariant Section.</li>
 <li>O. Preserve any Warranty Disclaimers.</li>
 </ul>
-<p>If the Modified Version includes new front-matter sections or appendices that qualify as Secondary Sections and contain no material copied from the Document, you may at your option designate some or all of these sections as invariant. To do this, add their titles to the list of Invariant Sections in the Modified Version’s license notice. These titles must be distinct from any other section titles.</p>
-<p>You may add a section Entitled “Endorsements”, provided it contains nothing but endorsements of your Modified Version by various parties—for example, statements of peer review or that the text has been approved by an organization as the authoritative definition of a standard.</p>
-<p>You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25 words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version. Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or through arrangements made by) any one entity. If the Document already includes a cover text for the same cover, previously added by you or by arrangement made by the same entity you are acting on behalf of, you may not add another; but you may replace the old one, on explicit permission from the previous publisher that added the old one.</p>
-<p>The author(s) and publisher(s) of the Document do not by this License give permission to use their names for publicity for or to assert or imply endorsement of any Modified Version.</p>
+<p>If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant. To do this, add their titles to the list
+of Invariant Sections in the Modified Version’s license notice. These
+titles must be distinct from any other section titles.</p>
+<p>You may add a section Entitled “Endorsements”, provided it contains
+nothing but endorsements of your Modified Version by various parties—for
+example, statements of peer review or that the text has been approved by
+an organization as the authoritative definition of a standard.</p>
+<p>You may add a passage of up to five words as a Front-Cover Text, and
+a passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version. Only one passage of Front-Cover
+Text and one of Back-Cover Text may be added by (or through arrangements
+made by) any one entity. If the Document already includes a cover text
+for the same cover, previously added by you or by arrangement made by
+the same entity you are acting on behalf of, you may not add another;
+but you may replace the old one, on explicit permission from the
+previous publisher that added the old one.</p>
+<p>The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.</p>
 <h4 id="combining-documents">5. COMBINING DOCUMENTS</h4>
-<p>You may combine the Document with other documents released under this License, under the terms defined in section 4 above for modified versions, provided that you include in the combination all of the Invariant Sections of all of the original documents, unmodified, and list them all as Invariant Sections of your combined work in its license notice, and that you preserve all their Warranty Disclaimers.</p>
-<p>The combined work need only contain one copy of this License, and multiple identical Invariant Sections may be replaced with a single copy. If there are multiple Invariant Sections with the same name but different contents, make the title of each such section unique by adding at the end of it, in parentheses, the name of the original author or publisher of that section if known, or else a unique number. Make the same adjustment to the section titles in the list of Invariant Sections in the license notice of the combined work.</p>
-<p>In the combination, you must combine any sections Entitled “History” in the various original documents, forming one section Entitled “History”; likewise combine any sections Entitled “Acknowledgements”, and any sections Entitled “Dedications”. You must delete all sections Entitled “Endorsements”.</p>
+<p>You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its license
+notice, and that you preserve all their Warranty Disclaimers.</p>
+<p>The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy. If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by adding
+at the end of it, in parentheses, the name of the original author or
+publisher of that section if known, or else a unique number. Make the
+same adjustment to the section titles in the list of Invariant Sections
+in the license notice of the combined work.</p>
+<p>In the combination, you must combine any sections Entitled “History”
+in the various original documents, forming one section Entitled
+“History”; likewise combine any sections Entitled “Acknowledgements”,
+and any sections Entitled “Dedications”. You must delete all sections
+Entitled “Endorsements”.</p>
 <h4 id="collections-of-documents">6. COLLECTIONS OF DOCUMENTS</h4>
-<p>You may make a collection consisting of the Document and other documents released under this License, and replace the individual copies of this License in the various documents with a single copy that is included in the collection, provided that you follow the rules of this License for verbatim copying of each of the documents in all other respects.</p>
-<p>You may extract a single document from such a collection, and distribute it individually under this License, provided you insert a copy of this License into the extracted document, and follow this License in all other respects regarding verbatim copying of that document.</p>
-<h4 id="aggregation-with-independent-works">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
-<p>A compilation of the Document or its derivatives with other separate and independent documents or works, in or on a volume of a storage or distribution medium, is called an “aggregate” if the copyright resulting from the compilation is not used to limit the legal rights of the compilation’s users beyond what the individual works permit. When the Document is included in an aggregate, this License does not apply to the other works in the aggregate which are not themselves derivative works of the Document.</p>
-<p>If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if the Document is less than one half of the entire aggregate, the Document’s Cover Texts may be placed on covers that bracket the Document within the aggregate, or the electronic equivalent of covers if the Document is in electronic form. Otherwise they must appear on printed covers that bracket the whole aggregate.</p>
+<p>You may make a collection consisting of the Document and other
+documents released under this License, and replace the individual copies
+of this License in the various documents with a single copy that is
+included in the collection, provided that you follow the rules of this
+License for verbatim copying of each of the documents in all other
+respects.</p>
+<p>You may extract a single document from such a collection, and
+distribute it individually under this License, provided you insert a
+copy of this License into the extracted document, and follow this
+License in all other respects regarding verbatim copying of that
+document.</p>
+<h4 id="aggregation-with-independent-works">7. AGGREGATION WITH
+INDEPENDENT WORKS</h4>
+<p>A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an “aggregate” if the copyright resulting
+from the compilation is not used to limit the legal rights of the
+compilation’s users beyond what the individual works permit. When the
+Document is included in an aggregate, this License does not apply to the
+other works in the aggregate which are not themselves derivative works
+of the Document.</p>
+<p>If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document’s Cover Texts may be placed on covers
+that bracket the Document within the aggregate, or the electronic
+equivalent of covers if the Document is in electronic form. Otherwise
+they must appear on printed covers that bracket the whole aggregate.</p>
 <h4 id="translation">8. TRANSLATION</h4>
-<p>Translation is considered a kind of modification, so you may distribute translations of the Document under the terms of section 4. Replacing Invariant Sections with translations requires special permission from their copyright holders, but you may include translations of some or all Invariant Sections in addition to the original versions of these Invariant Sections. You may include a translation of this License, and all the license notices in the Document, and any Warranty Disclaimers, provided that you also include the original English version of this License and the original versions of those notices and disclaimers. In case of a disagreement between the translation and the original version of this License or a notice or disclaimer, the original version will prevail.</p>
-<p>If a section in the Document is Entitled “Acknowledgements”, “Dedications”, or “History”, the requirement (section 4) to Preserve its Title (section 1) will typically require changing the actual title.</p>
+<p>Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections. You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers. In case of a disagreement between the
+translation and the original version of this License or a notice or
+disclaimer, the original version will prevail.</p>
+<p>If a section in the Document is Entitled “Acknowledgements”,
+“Dedications”, or “History”, the requirement (section 4) to Preserve its
+Title (section 1) will typically require changing the actual title.</p>
 <h4 id="termination">9. TERMINATION</h4>
-<p>You may not copy, modify, sublicense, or distribute the Document except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, or distribute it is void, and will automatically terminate your rights under this License.</p>
-<p>However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.</p>
-<p>Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
-<p>Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, receipt of a copy of some or all of the same material does not give you any rights to use it.</p>
-<h4 id="future-revisions-of-this-license">10. FUTURE REVISIONS OF THIS LICENSE</h4>
-<p>The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. See <a href="https://www.gnu.org/licenses/" class="uri">https://www.gnu.org/licenses/</a>.</p>
-<p>Each version of the License is given a distinguishing version number. If the Document specifies that a particular numbered version of this License “or any later version” applies to it, you have the option of following the terms and conditions either of that specified version or of any later version that has been published (not as a draft) by the Free Software Foundation. If the Document does not specify a version number of this License, you may choose any version ever published (not as a draft) by the Free Software Foundation. If the Document specifies that a proxy can decide which future versions of this License can be used, that proxy’s public statement of acceptance of a version permanently authorizes you to choose that version for the Document.</p>
+<p>You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided under this License. Any attempt otherwise
+to copy, modify, sublicense, or distribute it is void, and will
+automatically terminate your rights under this License.</p>
+<p>However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.</p>
+<p>Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after your
+receipt of the notice.</p>
+<p>Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License. If your rights have been terminated and not permanently
+reinstated, receipt of a copy of some or all of the same material does
+not give you any rights to use it.</p>
+<h4 id="future-revisions-of-this-license">10. FUTURE REVISIONS OF THIS
+LICENSE</h4>
+<p>The Free Software Foundation may publish new, revised versions of the
+GNU Free Documentation License from time to time. Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns. See <a
+href="https://www.gnu.org/licenses/"
+class="uri">https://www.gnu.org/licenses/</a>.</p>
+<p>Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License “or any later version” applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation. If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation. If the Document specifies
+that a proxy can decide which future versions of this License can be
+used, that proxy’s public statement of acceptance of a version
+permanently authorizes you to choose that version for the Document.</p>
 <h4 id="relicensing">11. RELICENSING</h4>
-<p>“Massive Multiauthor Collaboration Site” (or “MMC Site”) means any World Wide Web server that publishes copyrightable works and also provides prominent facilities for anybody to edit those works. A public wiki that anybody can edit is an example of such a server. A “Massive Multiauthor Collaboration” (or “MMC”) contained in the site means any set of copyrightable works thus published on the MMC site.</p>
-<p>“CC-BY-SA” means the Creative Commons Attribution-Share Alike 3.0 license published by Creative Commons Corporation, a not-for-profit corporation with a principal place of business in San Francisco, California, as well as future copyleft versions of that license published by that same organization.</p>
-<p>“Incorporate” means to publish or republish a Document, in whole or in part, as part of another Document.</p>
-<p>An MMC is “eligible for relicensing” if it is licensed under this License, and if all works that were first published under this License somewhere other than this MMC, and subsequently incorporated in whole or in part into the MMC, (1) had no cover texts or invariant sections, and (2) were thus incorporated prior to November 1, 2008.</p>
-<p>The operator of an MMC Site may republish an MMC contained in the site under CC-BY-SA on the same site at any time before August 1, 2009, provided the MMC is eligible for relicensing.</p>
-<h3 id="addendum-how-to-use-this-license-for-your-documents">ADDENDUM: How to use this License for your documents</h3>
-<p>To use this License in a document you have written, include a copy of the License in the document and put the following copyright and license notices just after the title page:</p>
+<p>“Massive Multiauthor Collaboration Site” (or “MMC Site”) means any
+World Wide Web server that publishes copyrightable works and also
+provides prominent facilities for anybody to edit those works. A public
+wiki that anybody can edit is an example of such a server. A “Massive
+Multiauthor Collaboration” (or “MMC”) contained in the site means any
+set of copyrightable works thus published on the MMC site.</p>
+<p>“CC-BY-SA” means the Creative Commons Attribution-Share Alike 3.0
+license published by Creative Commons Corporation, a not-for-profit
+corporation with a principal place of business in San Francisco,
+California, as well as future copyleft versions of that license
+published by that same organization.</p>
+<p>“Incorporate” means to publish or republish a Document, in whole or
+in part, as part of another Document.</p>
+<p>An MMC is “eligible for relicensing” if it is licensed under this
+License, and if all works that were first published under this License
+somewhere other than this MMC, and subsequently incorporated in whole or
+in part into the MMC, (1) had no cover texts or invariant sections, and
+(2) were thus incorporated prior to November 1, 2008.</p>
+<p>The operator of an MMC Site may republish an MMC contained in the
+site under CC-BY-SA on the same site at any time before August 1, 2009,
+provided the MMC is eligible for relicensing.</p>
+<h3 id="addendum-how-to-use-this-license-for-your-documents">ADDENDUM:
+How to use this License for your documents</h3>
+<p>To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and license
+notices just after the title page:</p>
 <pre><code>    Copyright (C)  YEAR  YOUR NAME.
     Permission is granted to copy, distribute and/or modify this document
     under the terms of the GNU Free Documentation License, Version 1.3
@@ -2690,11 +4660,17 @@ end;</code></pre>
     with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
     A copy of the license is included in the section entitled &quot;GNU
     Free Documentation License&quot;.</code></pre>
-<p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts, replace the “with … Texts.” line with this:</p>
+<p>If you have Invariant Sections, Front-Cover Texts and Back-Cover
+Texts, replace the “with … Texts.” line with this:</p>
 <pre><code>    with the Invariant Sections being LIST THEIR TITLES, with the
     Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.</code></pre>
-<p>If you have Invariant Sections without Cover Texts, or some other combination of the three, merge those two alternatives to suit the situation.</p>
-<p>If your document contains nontrivial examples of program code, we recommend releasing these examples in parallel under your choice of free software license, such as the GNU General Public License, to permit their use in free software.</p>
+<p>If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.</p>
+<p>If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of free
+software license, such as the GNU General Public License, to permit
+their use in free software.</p>
         </article>
       </div>
       <footer>


### PR DESCRIPTION
austral/austral#383 removes these.

also running `make all` inserted `id="toc-foo"` attributes into the `<a>` tags that weren't there before, along with a bunch of whitespaces alterations, not sure what triggered that. different pandoc version?