### PR TITLE
Fix typo in Design Goals section of spec

### DIFF
--- a/_spec/goals.md
+++ b/_spec/goals.md
@@ -101,7 +101,7 @@ This section lists the design goals for Austral.
    Modula-3) or functors (as in Standard ML or OCaml), that is: all modules are
    first-order.
 
-   Modules are given explicit names are are not tied to any particular file
+   Modules are given explicit names and are not tied to any particular file
    system structure. Modules are split in two textual parts (effectively two
    files), a module interface and a module body, with strict separation between
    the two. The declarations in the module interface file are accessible from

--- a/spec/spec.html
+++ b/spec/spec.html
@@ -311,7 +311,7 @@ declarations to make them public or private.</p></li>
 Standard ML, with the restriction that there are no generic modules (as
 in Ada or Modula-3) or functors (as in Standard ML or OCaml), that is:
 all modules are first-order.</p>
-<p>Modules are given explicit names are are not tied to any particular
+<p>Modules are given explicit names and are not tied to any particular
 file system structure. Modules are split in two textual parts
 (effectively two files), a module interface and a module body, with
 strict separation between the two. The declarations in the module


### PR DESCRIPTION
Just wanted to fix a little typo I noticed while reading over the spec last night. Because I didn't change the layout of the document I figured it was fine to edit the HTML manually, but if I should re-build it using the Makefile instead let me know!