### PR TITLE
Fixed broken link to SICP preface

### DIFF
--- a/spec/spec.html
+++ b/spec/spec.html
@@ -325,7 +325,7 @@ system interfaces to be designed up-front, and implemented in
 parallel.</p></li>
 <li><p><strong>Strictness.</strong> Gerald Jay Sussman and Hal Abelson
 <a
-href="https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book-Z-H-5.html">wrote</a>:</p>
+href="https://mitp-content-server.mit.edu/books/content/sectbyfn/books_pres_0/6515/sicp.zip/full-text/book/book-Z-H-5.html">wrote</a>:</p>
 <blockquote>
 <p>Pascal is for building pyramids — imposing, breathtaking, static
 structures built by armies pushing heavy blocks into place. Lisp is for


### PR DESCRIPTION
MIT press has recently changed their URL structure for full text of books and all the old links are broken now. Replaced the broken one with the working link.