### PR TITLE
Fix typos

### DIFF
--- a/_spec/austral-memory.md
+++ b/_spec/austral-memory.md
@@ -129,7 +129,7 @@ Declaration:
 
 ```austral
 generic [T: Type]
-function resizeArray(array: Pointer[T], size: Index): Pointer[T];
+function resizeArray(array: Pointer[T], size: Index): Option[Pointer[T]];
 ```
 
 Description:

--- a/_spec/rationale-capabilities.md
+++ b/_spec/rationale-capabilities.md
@@ -96,7 +96,7 @@ let secrets: String := readFile(&p);
 
 In the context of code running on a programmer's development computer, that
 means personal information. In the context of code running on an application
-server, that means confidential bussiness information.
+server, that means confidential business information.
 
 What does a capability-secure filesystem API look like? Like this:
 

--- a/_spec/rationale-linear-types.md
+++ b/_spec/rationale-linear-types.md
@@ -694,7 +694,7 @@ The `openFile` function looks like this:
 extern int fopen(char* filename, char* mode)
 
 File openFile(String path) {
-    let handle: int = fopen(as_c_string(filename), "r");
+    let ptr: int = fopen(as_c_string(filename), "r");
     return File(handle => ptr);
 }
 ```
@@ -710,7 +710,7 @@ extern int fputs(char* string, int fp)
 File writeString(File file, String content) {
   let { handle: int } := file;
   fputs(as_c_string(content), handle);
-  return File(handle => ptr);
+  return File(handle => handle);
 }
 ```
 


### PR DESCRIPTION
- bussiness -> business
- The text for `resizeArray` implies it returns an Option but the declaration above it just returned a plain Pointer[T]. This might not be relevant anymore since it seems to be out of sync with the actual code
- Fix mismatching variable names in file handle example. `handle => handle` is confusing but the destructuring syntax seems to enforce it. See #50