### PR TITLE
Update tutorial build instructions

### DIFF
--- a/tutorial/getting-started-linux.md
+++ b/tutorial/getting-started-linux.md
@@ -7,7 +7,7 @@ it from source.
 
 ## Downloading a Release
 
-Run this to download and install the latest release:
+Run this to download and install the latest release for [Nix][nix]:
 
 ```bash
 $ curl -o austral -L https://github.com/austral/austral/releases/latest/download/austral-linux
@@ -18,29 +18,59 @@ Then you can invoke `austral` from the command line.
 
 ## Building from Source
 
-First, you need to install [opam][opam], the package manager for OCaml. On
-Debian/Ubuntu, this is simply:
+### Building with Nix
+
+If you have [Nix][nix], this will be much simpler. Just:
+
+[nix]: https://nixos.org/
+
+```bash
+$ nix-shell
+$ make
+```
+
+And you're done.
+
+### Building without Nix
+
+Building the `austral` compiler requires `make` and the `dune` build system for
+OCaml, and a C compiler for building the resulting output. You should install
+OCaml 4.13.0 or above.
+
+First:
+
+```bash
+$ git clone git@github.com:austral/austral.git
+$ cd austral
+```
+
+Next, install [opam][opam]. On Debian/Ubuntu you can just do:
 
 ```bash
 $ sudo apt-get install opam
-```
-
-Then, set up the OCaml compiler environment:
-
-```bash
 $ opam init
-$ opam switch install 4.13.0
 ```
 
-Then, download and build Austral:
+Then, create an opam switch for austral and install dependencies via opam:
 
 ```bash
-$ git clone https://github.com/austral/austral.git
-$ cd austral
-$ ./install-ocaml-deps.sh
-$ make
-$ sudo make install
+opam switch create austral 4.13.0
+eval $(opam env --switch=austral)
+opam install --deps-only -y .
 ```
+
+Finally:
+```bash
+make
+```
+
+To build the standard library:
+
+```bash
+$ cd standard
+$ make
+```
+
 
 ### Navigation
 


### PR DESCRIPTION
The build instructions for the tutorial seemed to be out of date when following along. This change brings in the instructions from the language repo's README. 