### PR TITLE
document renaming in let-destructure and case statements

### DIFF
--- a/_spec/statements.md
+++ b/_spec/statements.md
@@ -28,9 +28,9 @@ A `let` statement is one of the few places where type information flows forward:
 the declared type is used to disambiguate the type of the expression when the
 expression is, for example, a call to a return-type polymorphic function.
 
-## Let Destructure Statement {#stmt-let-destructure}
+## Let-destructure Statement {#stmt-let-destructure}
 
-A let destructure statement is used to break apart records, creating a binding
+A let-destructure statement is used to break apart records, creating a binding
 for each field in the record.
 
 The utility of this is: when you have a linear record type, you can't extract
@@ -45,7 +45,33 @@ If `R` is an expression of type `T`, and `T` is a record type with field set
 let {R_1: T_1, ..., R_n: T_n} := R;
 ```
 
-is a let destructure statement.
+is a let-destructure statement.
+
+Since there are likely to be collisions between record field names and existing
+variable names, let-destructure statements optionally support assigning to a
+different name.
+
+If `R` is an expression of type `T`, and `T` is a record type with field set
+`{R_1: T_1, ..., R_n: T_n}`, and `N_i` is an identifier, then:
+
+```austral
+let {..., R_i as N_i: T_i, ...} := R;
+```
+
+is a let-destructure statement with renaming. None, some, or all of the
+destructed fields may be renamed.
+
+An example of a let-destructure statement with no renaming:
+
+```austral
+let { symbol: String, Z: Nat8, A: Nat8 } := isotope;
+```
+
+An example of a let-destructure statement with some fields renamed:
+
+```austral
+let { symbol: String, Z as atomic_number: Nat8, A as mass_number: Nat8 } := isotope;
+```
 
 ## Assignment Statement {#stmt-assign}
 
@@ -188,7 +214,36 @@ case e of
 end case;
 ```
 
-An exam
+Since there are likely to be collisions between union case slot names and existing
+variable names, case statements optionally support assigning to a
+different name.
+
+If `E` is an expression of a union type with cases `{C_1, ..., C_n}` and each
+case has slots `C_i = {S_i1: T_i1, ..., S_in T_im}`, and `{B_1, ..., B_n}` is a
+set of statements, and `N_ij` is an identifier, then:
+
+```austral
+case E of
+    ...
+    when C_i(..., S_ij as N_ij: T_ij, ...) do
+        B_i;
+    ...
+end case;
+```
+
+is a `case` statement with renaming. None, some, or all of the union case slots
+may be renamed.
+
+An example of a case statement with renaming:
+
+```austral
+case response of
+    when Some(value as payload: String) do
+        -- do something with the response payload
+    when None do
+        -- handle the failure case
+end case;
+```
 
 
 ## While Loop {#stmt-while}

--- a/_spec/statements.md
+++ b/_spec/statements.md
@@ -48,7 +48,7 @@ let {R_1: T_1, ..., R_n: T_n} := R;
 is a let-destructure statement.
 
 Since there are likely to be collisions between record field names and existing
-variable names, let-destructure statements optionally support assigning to a
+variable names, let-destructure statements optionally support binding to a
 different name.
 
 If `R` is an expression of type `T`, and `T` is a record type with field set
@@ -59,7 +59,7 @@ let {..., R_i as N_i: T_i, ...} := R;
 ```
 
 is a let-destructure statement with renaming. None, some, or all of the
-destructed fields may be renamed.
+bindings may be renamed.
 
 An example of a let-destructure statement with no renaming:
 
@@ -67,7 +67,7 @@ An example of a let-destructure statement with no renaming:
 let { symbol: String, Z: Nat8, A: Nat8 } := isotope;
 ```
 
-An example of a let-destructure statement with some fields renamed:
+An example of a let-destructure statement with some bindings renamed:
 
 ```austral
 let { symbol: String, Z as atomic_number: Nat8, A as mass_number: Nat8 } := isotope;
@@ -215,7 +215,7 @@ end case;
 ```
 
 Since there are likely to be collisions between union case slot names and existing
-variable names, case statements optionally support assigning to a
+variable names, case statements optionally support binding to a
 different name.
 
 If `E` is an expression of a union type with cases `{C_1, ..., C_n}` and each
@@ -231,10 +231,10 @@ case E of
 end case;
 ```
 
-is a `case` statement with renaming. None, some, or all of the union case slots
-may be renamed.
+is a `case` statement with renaming. None, some, or all of the bindings may be
+renamed.
 
-An example of a case statement with renaming:
+An example of a case statement with a renamed binding:
 
 ```austral
 case response of
@@ -244,7 +244,6 @@ case response of
         -- handle the failure case
 end case;
 ```
-
 
 ## While Loop {#stmt-while}
 

--- a/spec/spec.html
+++ b/spec/spec.html
@@ -118,7 +118,7 @@
           <li><a href="#stmt-let" id="toc-stmt-let">Let
           Statement</a></li>
           <li><a href="#stmt-let-destructure"
-          id="toc-stmt-let-destructure">Let Destructure
+          id="toc-stmt-let-destructure">Let-destructure
           Statement</a></li>
           <li><a href="#stmt-assign" id="toc-stmt-assign">Assignment
           Statement</a></li>
@@ -3458,8 +3458,8 @@ then:</p>
 information flows forward: the declared type is used to disambiguate the
 type of the expression when the expression is, for example, a call to a
 return-type polymorphic function.</p>
-<h2 id="stmt-let-destructure">Let Destructure Statement</h2>
-<p>A let destructure statement is used to break apart records, creating
+<h2 id="stmt-let-destructure">Let-destructure Statement</h2>
+<p>A let-destructure statement is used to break apart records, creating
 a binding for each field in the record.</p>
 <p>The utility of this is: when you have a linear record type, you can’t
 extract the value of a linear field from it, because it consumes the
@@ -3470,7 +3470,22 @@ then optionally reassembled.</p>
 <code>T</code> is a record type with field set
 <code>{R_1: T_1, ..., R_n: T_n}</code>, then:</p>
 <pre class="austral"><code>let {R_1: T_1, ..., R_n: T_n} := R;</code></pre>
-<p>is a let destructure statement.</p>
+<p>is a let-destructure statement.</p>
+<p>Since there are likely to be collisions between record field names
+and existing variable names, let-destructure statements optionally
+support assigning to a different name.</p>
+<p>If <code>R</code> is an expression of type <code>T</code>, and
+<code>T</code> is a record type with field set
+<code>{R_1: T_1, ..., R_n: T_n}</code>, and <code>N_i</code> is an
+identifier, then:</p>
+<pre class="austral"><code>let {..., R_i as N_i: T_i, ...} := R;</code></pre>
+<p>is a let-destructure statement with renaming. None, some, or all of
+the destructed fields may be renamed.</p>
+<p>An example of a let-destructure statement with no renaming:</p>
+<pre class="austral"><code>let { symbol: String, Z: Nat8, A: Nat8 } := isotope;</code></pre>
+<p>An example of a let-destructure statement with some fields
+renamed:</p>
+<pre class="austral"><code>let { symbol: String, Z as atomic_number: Nat8, A as mass_number: Nat8 } := isotope;</code></pre>
 <h2 id="stmt-assign">Assignment Statement</h2>
 <p>If <code>P</code> is an lvalue of type <code>T</code> and
 <code>E</code> is an expression of type <code>T</code>, then:</p>
@@ -3573,7 +3588,29 @@ case e of
     when Right(right: Int32) do
         -- Do something with `right`.
 end case;</code></pre>
-<p>An exam</p>
+<p>Since there are likely to be collisions between union case slot names
+and existing variable names, case statements optionally support
+assigning to a different name.</p>
+<p>If <code>E</code> is an expression of a union type with cases
+<code>{C_1, ..., C_n}</code> and each case has slots
+<code>C_i = {S_i1: T_i1, ..., S_in T_im}</code>, and
+<code>{B_1, ..., B_n}</code> is a set of statements, and
+<code>N_ij</code> is an identifier, then:</p>
+<pre class="austral"><code>case E of
+    ...
+    when C_i(..., S_ij as N_ij: T_ij, ...) do
+        B_i;
+    ...
+end case;</code></pre>
+<p>is a <code>case</code> statement with renaming. None, some, or all of
+the union case slots may be renamed.</p>
+<p>An example of a case statement with renaming:</p>
+<pre class="austral"><code>case response of
+    when Some(value as payload: String) do
+        -- do something with the response payload
+    when None do
+        -- handle the failure case
+end case;</code></pre>
 <h2 id="stmt-while">While Loop</h2>
 <p>If <code>e</code> is an expression of type <code>Bool</code> and
 <code>b</code> is a statement, then:</p>

--- a/spec/spec.html
+++ b/spec/spec.html
@@ -3473,17 +3473,17 @@ then optionally reassembled.</p>
 <p>is a let-destructure statement.</p>
 <p>Since there are likely to be collisions between record field names
 and existing variable names, let-destructure statements optionally
-support assigning to a different name.</p>
+support binding to a different name.</p>
 <p>If <code>R</code> is an expression of type <code>T</code>, and
 <code>T</code> is a record type with field set
 <code>{R_1: T_1, ..., R_n: T_n}</code>, and <code>N_i</code> is an
 identifier, then:</p>
 <pre class="austral"><code>let {..., R_i as N_i: T_i, ...} := R;</code></pre>
 <p>is a let-destructure statement with renaming. None, some, or all of
-the destructed fields may be renamed.</p>
+the bindings may be renamed.</p>
 <p>An example of a let-destructure statement with no renaming:</p>
 <pre class="austral"><code>let { symbol: String, Z: Nat8, A: Nat8 } := isotope;</code></pre>
-<p>An example of a let-destructure statement with some fields
+<p>An example of a let-destructure statement with some bindings
 renamed:</p>
 <pre class="austral"><code>let { symbol: String, Z as atomic_number: Nat8, A as mass_number: Nat8 } := isotope;</code></pre>
 <h2 id="stmt-assign">Assignment Statement</h2>
@@ -3589,8 +3589,8 @@ case e of
         -- Do something with `right`.
 end case;</code></pre>
 <p>Since there are likely to be collisions between union case slot names
-and existing variable names, case statements optionally support
-assigning to a different name.</p>
+and existing variable names, case statements optionally support binding
+to a different name.</p>
 <p>If <code>E</code> is an expression of a union type with cases
 <code>{C_1, ..., C_n}</code> and each case has slots
 <code>C_i = {S_i1: T_i1, ..., S_in T_im}</code>, and
@@ -3603,8 +3603,8 @@ assigning to a different name.</p>
     ...
 end case;</code></pre>
 <p>is a <code>case</code> statement with renaming. None, some, or all of
-the union case slots may be renamed.</p>
-<p>An example of a case statement with renaming:</p>
+the bindings may be renamed.</p>
+<p>An example of a case statement with a renamed binding:</p>
 <pre class="austral"><code>case response of
     when Some(value as payload: String) do
         -- do something with the response payload


### PR DESCRIPTION
This stuff wasn't documented. I have not actually tested these code examples but I looked at the `Parser.mly` file and this seems to be how it works