### PR TITLE
Update string docs to say they're `Span`

### DIFF
--- a/tutorial/basic-types.md
+++ b/tutorial/basic-types.md
@@ -147,30 +147,29 @@ work on floats as well, but the usual restrictions apply: you can't mix
 different float types, or floats and integers, in the same expression, you have
 to convert them.
 
-# Fixed Arrays
+# Spans
 
-Fixed arrays are the type of (usually statically allocated) arrays. String
-literals are fixed arrays of bytes:
+String literals are spans of bytes:
 
 ```austral
-let str: FixedArray[Nat8] := "Hello, world!";
+let str: Span[Nat8, Static] := "Hello, world!";
 ```
 
-The size of a fixed array can be obtained with the built-in `fixedArraySize`
-function, which takes a fixed array and returns a value of type `Index`:
+The size of a span can be obtained with the built-in `spanLength` function,
+which takes a span and returns a value of type `Index`:
 
 ```austral
-let size: Index := fixedArraySize("Hello, world!");
+let size: Index := spanLength("Hello, world!");
 ```
 
-Array elements can be accessed through the index operator:
+Span elements can be accessed through the index operator:
 
 ```austral
-let str: FixedArray[Nat8] := "Hello, world!";
+let str: Span[Nat8, Static] := "Hello, world!";
 printLn(str[0]);
 ```
 
-If an array index is out-of-bounds, the program aborts.
+If an index is out-of-bounds, the program aborts.
 
 ### Navigation
 


### PR DESCRIPTION
Currently this `FixedArray` part of the tutorial fails with the following error message:

```
Compiler call tree printed to calltree.html
Error:
  Title: Type Error
  Module:
    Hello
  Location:
    Filename: 'hello.aum'
    From: line 3, column 8
    To: line 3, column 53
  Description:
    Unable to find a type with the name `FixedArray`.
    
    Consider importing it, if it is defined in another module.
  Code:
    1 | module body Hello is
    2 |     function main(): ExitCode is
    3 |         let str: FixedArray[Nat8] := "Hello, world!";
    4 |         printLn(str);
    5 |         return ExitSuccess();
```

This PR updates it so it compiles and runs.