### PR TITLE
Replace compromised polyfill.io CDN with cdnjs

### DIFF
--- a/_spec/template.html
+++ b/_spec/template.html
@@ -43,7 +43,7 @@ $body$
         &copy; 2021&ndash;2022 <a href="https://borretti.me/">Fernando Borretti</a>
       </footer>
     </div>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill//v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   </body>
 </html>

--- a/spec/spec.html
+++ b/spec/spec.html
@@ -4725,7 +4725,7 @@ their use in free software.</p>
         &copy; 2021&ndash;2022 <a href="https://borretti.me/">Fernando Borretti</a>
       </footer>
     </div>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill//v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   </body>
 </html>


### PR DESCRIPTION
polyfill.io is [known to be compromised and to host malware](https://sansec.io/research/polyfill-supply-chain-attack). Loading it on Austral's language spec page currently causes an unneeded HTTP basic authentication prompt as seen in the screenshot below:

<img width="1956" height="528" alt="polyfill io-authentication-dialog" src="https://github.com/user-attachments/assets/9a1cbbe6-a39d-4484-ac9a-46bc00ea9be3" />

Fix this issue and avoid future ones by using [Cloudflare's cdnjs endpoint for polyfill.io](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/).

Fastly also offers [an alternative CDN for polyfill.io](https://polyfill-fastly.io/) if that's preferred.